### PR TITLE
Full i18n coverage and deploy.yml env-based registry username

### DIFF
--- a/app/controllers/admin/games_controller.rb
+++ b/app/controllers/admin/games_controller.rb
@@ -19,7 +19,7 @@ module Admin
       params[:game][:reason] = nil if params[:game][:status].to_i != 2
 
       if @game.update(game_params)
-        flash[:success] = 'Игра успешно обновлена'
+        flash[:success] = t('controllers.admin.games.updated')
 
         if old_game.status != @game.status
           @author = @game.author
@@ -37,7 +37,7 @@ module Admin
 
     def destroy
       create_administration_record(current_user, @game, {}, 'delete') if @game.destroy
-      flash[:success] = 'Игра успешно удалена'
+      flash[:success] = t('controllers.admin.games.deleted')
       redirect_to admin_games_path
     end
 

--- a/app/controllers/admin/games_controller.rb
+++ b/app/controllers/admin/games_controller.rb
@@ -23,7 +23,7 @@ module Admin
 
         if old_game.status != @game.status
           @author = @game.author
-          @author.create_notification(@author, current_user, 'game change status after moderation', @game)
+          @author.create_notification(@author, current_user, 'game_status_changed', @game)
         end
 
         changes = @game.previous_changes.except('updated_at')

--- a/app/controllers/admin/jams_controller.rb
+++ b/app/controllers/admin/jams_controller.rb
@@ -22,7 +22,7 @@ module Admin
         flash[:success] = t('controllers.admin.jams.updated')
         if old_jam.status != @jam.status
           @author = @jam.author
-          @author.create_notification(@author, current_user, 'jam change status after moderation', @jam)
+          @author.create_notification(@author, current_user, 'jam_status_changed', @jam)
         end
 
         changes = @jam.previous_changes.except('updated_at')

--- a/app/controllers/admin/jams_controller.rb
+++ b/app/controllers/admin/jams_controller.rb
@@ -19,7 +19,7 @@ module Admin
       params[:jam][:reason] = nil if params[:jam][:status].to_i != 2
 
       if @jam.update(jam_params)
-        flash[:success] = 'Джем успешно обновлен'
+        flash[:success] = t('controllers.admin.jams.updated')
         if old_jam.status != @jam.status
           @author = @jam.author
           @author.create_notification(@author, current_user, 'jam change status after moderation', @jam)
@@ -36,7 +36,7 @@ module Admin
 
     def destroy
       create_administration_record(current_user, @jam, {}, 'delete') if @jam.destroy
-      flash[:success] = 'Джем успешно удален'
+      flash[:success] = t('controllers.admin.jams.deleted')
       redirect_to admin_jams_path
     end
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -14,7 +14,7 @@ module Admin
       @user = User.new(user_params)
 
       if @user.save
-        flash[:success] = 'Пользователь успешно создан'
+        flash[:success] = t('controllers.admin.users.created')
 
         create_administration_record(current_user, @user, {}, 'create')
 
@@ -43,7 +43,7 @@ module Admin
 
     def update
       if @user.update(user_params)
-        flash[:success] = 'Пользователь успешно обновлен'
+        flash[:success] = t('controllers.admin.users.updated')
 
         changes = @user.previous_changes.except('updated_at')
 
@@ -58,7 +58,7 @@ module Admin
 
     def destroy
       create_administration_record(current_user, @user, {}, 'delete') if @user.destroy
-      flash[:success] = 'Пользователь успешно удален'
+      flash[:success] = t('controllers.admin.users.deleted')
       redirect_to admin_users_path
     end
 
@@ -79,7 +79,7 @@ module Admin
                     when "1.year" then 1.year.from_now
                     when "forever" then nil
                     else
-                      return render json: { error: "Некорректный срок" }, status: :unprocessable_entity
+                      return render json: { error: t('controllers.admin.users.invalid_duration') }, status: :unprocessable_entity
                     end
 
       if user.update!(
@@ -90,7 +90,7 @@ module Admin
       )
         render json: { success: true }, status: :ok
       else
-        render json: { error: "Не удалось заморозить пользователя" }, status: :unprocessable_entity
+        render json: { error: t('controllers.admin.users.freeze_failed') }, status: :unprocessable_entity
       end
     end
 
@@ -104,7 +104,7 @@ module Admin
       )
         render json: { success: true }, status: :ok
       else
-        render json: { error: "Не удалось разморозить пользователя" }, status: :unprocessable_entity
+        render json: { error: t('controllers.admin.users.unfreeze_failed') }, status: :unprocessable_entity
       end
     end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -58,7 +58,7 @@ class ApplicationController < ActionController::Base
     @user = current_user
     return if @user && @user.role == 'admin'
 
-    flash[:failure] = 'Недостаточно прав'
+    flash[:failure] = t('controllers.application.insufficient_rights')
     redirect_to dashboard_path
   end
 
@@ -67,7 +67,7 @@ class ApplicationController < ActionController::Base
     # Права администратора включают в себя права модератора и выше, поэтому такая проверка
     return unless @user && @user.role == 'basic'
 
-    flash[:failure] = 'Недостаточно прав'
+    flash[:failure] = t('controllers.application.insufficient_rights')
     redirect_to dashboard_path
   end
 
@@ -97,9 +97,9 @@ class ApplicationController < ActionController::Base
     )
 
     if administration_record.save
-      Rails.logger.info("Запись успешно сохранена: #{administration_record.inspect}")
+      Rails.logger.info("Administration record saved: #{administration_record.inspect}")
     else
-      Rails.logger.error("Ошибка при сохранении записи: #{administration_record.errors.full_messages.join(', ')}")
+      Rails.logger.error("Failed to save administration record: #{administration_record.errors.full_messages.join(', ')}")
     end
   end
 
@@ -180,7 +180,7 @@ class ApplicationController < ActionController::Base
     if current_user.unfreeze_at && current_user.unfreeze_at < Time.current
       current_user.update(frozen_at: nil, unfreeze_at: nil, frozen_reason: nil, is_frozen: false)
     else
-      flash[:alert] = 'Ваш аккаунт заморожен'
+      flash[:alert] = t('controllers.application.account_frozen')
       redirect_to dashboard_path unless request.fullpath == dashboard_path
     end
   end

--- a/app/controllers/email_confirms_controller.rb
+++ b/app/controllers/email_confirms_controller.rb
@@ -13,11 +13,11 @@ class EmailConfirmsController < ApplicationController
       end
       remember(@user) if params[:remember_me] == '1'
       flash[:success] ||= []
-      flash[:success] << 'Email Confirmed successfully.'
+      flash[:success] << t('email_confirms.update.success')
       redirect_to dashboard_path
     else
       flash[:failure] ||= []
-      flash[:failure] << 'Something went wrong.'
+      flash[:failure] << t('email_confirms.update.failure')
       redirect_to register_path
     end
   end
@@ -27,7 +27,7 @@ class EmailConfirmsController < ApplicationController
   def check_params
     if params[:user][:code].blank?
       flash[:failure] ||= []
-      flash[:failure] << "Код не может быть пуст"
+      flash[:failure] << t('email_confirms.update.code_blank')
       redirect_to request.fullpath
     end
   end
@@ -36,7 +36,7 @@ class EmailConfirmsController < ApplicationController
     @user = User.find_by(email: params[:user][:email])
     unless @user
       flash[:failure] ||= []
-      flash[:failure] << "Пользователь не найден."
+      flash[:failure] << t('email_confirms.update.user_not_found')
       redirect_to register_path
     end
   end
@@ -46,7 +46,7 @@ class EmailConfirmsController < ApplicationController
     @user = nil unless @user.authenticate_email_confirm_token(params[:user][:code])
     unless @user&.email_confirm_period_valid?
       flash[:failure] ||= []
-      flash[:failure] << "Код недействителен!"
+      flash[:failure] << t('email_confirms.update.invalid_code')
       redirect_to request.fullpath
     end
   end

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -68,7 +68,7 @@ class FriendshipsController < ApplicationController
     existing_notifications = Notification.where(recipient: recipient, actor: actor, action: action)
 
     if existing_notifications.any?
-      # Удаляем старые уведомления из БД
+      # Remove old notifications from DB
       existing_notifications.destroy_all
     end
 

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -80,20 +80,20 @@ class GamesController < ApplicationController
     end
     return unless @game.status != 1 && current_user != @game.author
 
-    flash[:failure] = 'Игра находится на модерации'
+    flash[:failure] = t('controllers.games.moderation_pending')
     redirect_to dashboard_path
   end
 
   def submit
     submission = JamSubmission.find_by(jam_id: params[:jam_id], user_id: current_user.id)
     unless submission
-      flash[:failure] = "Вы не участвуете в этом джеме"
+      flash[:failure] = t('controllers.games.not_participating')
       return redirect_to jam_profile_path(params[:jam_id])
     end
 
     game = current_user.games.find_by(id: params[:id])
     unless game
-      flash[:failure] = "Игра не найдена"
+      flash[:failure] = t('controllers.games.not_found')
       return redirect_to jam_profile_path(params[:jam_id])
     end
 
@@ -163,7 +163,7 @@ class GamesController < ApplicationController
   def root_check
     return if current_user.games.find_by_id(params[:id])
 
-    flash[:failure] = 'Недостаточно прав'
+    flash[:failure] = t('controllers.application.insufficient_rights')
     redirect_to dashboard_path
   end
 
@@ -188,7 +188,7 @@ class GamesController < ApplicationController
     jam = submission.jam
     return if jam.submission_open?
 
-    flash[:failure] = "Приём работ завершён. Редактирование игры недоступно"
+    flash[:failure] = t('controllers.games.edit_locked')
     redirect_to game_profile_path(params[:id], jam_id: jam.id)
   end
 end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -107,7 +107,7 @@ class GamesController < ApplicationController
     if @game.save
       admins = User.where(role: [1, 2])
       admins.each do |admin|
-        current_user.create_notification(admin, current_user, 'awaiting game moderation', @game)
+        current_user.create_notification(admin, current_user, 'awaiting_game_moderation', @game)
       end
       flash[:success] ||= []
       flash[:success] << translate("games.create.success")
@@ -133,7 +133,7 @@ class GamesController < ApplicationController
     if @game.update(game_params)
       admins = User.where(role: [1, 2])
       admins.each do |admin|
-        current_user.create_notification(admin, current_user, 'awaiting game moderation', @game)
+        current_user.create_notification(admin, current_user, 'awaiting_game_moderation', @game)
       end
       @game.update(status: 0)
       flash[:success] ||= []

--- a/app/controllers/jam_criterion_picks_controller.rb
+++ b/app/controllers/jam_criterion_picks_controller.rb
@@ -21,7 +21,7 @@ class JamCriterionPicksController < ApplicationController
     pick.game_id = game.id
     pick.save!
 
-    flash.now[:success] = "Выбор сохранён"
+    flash.now[:success] = t('controllers.jam_criterion_picks.pick_saved')
 
     respond_to do |format|
       format.turbo_stream do
@@ -51,7 +51,7 @@ class JamCriterionPicksController < ApplicationController
     criterion = @jam.jam_criteria.find(pick.jam_criterion_id)
 
     pick.destroy!
-    flash.now[:success] = "Выбор сброшен"
+    flash.now[:success] = t('controllers.jam_criterion_picks.pick_cleared')
 
     respond_to do |format|
       format.turbo_stream do
@@ -78,18 +78,18 @@ class JamCriterionPicksController < ApplicationController
   # Можно использовать твою же authorize_vote! логику (voting_open? + rights)
   def authorize_vote_like!
     unless @jam.voting_open?
-      flash[:failure] = "Голосование сейчас закрыто"
+      flash[:failure] = t('controllers.jam_votes.voting_closed')
       redirect_to jam_profile_path(@jam) and return
     end
 
     setting = @jam.rating_setting
     unless setting.jury_enabled || setting.audience_enabled
-      flash[:failure] = "Голосование отключено"
+      flash[:failure] = t('controllers.jam_votes.voting_disabled')
       redirect_to jam_profile_path(@jam) and return
     end
 
     unless @jam.can_vote_as_jury?(current_user) || @jam.can_vote_as_audience?(current_user)
-      flash[:failure] = "Недостаточно прав для голосования"
+      flash[:failure] = t('controllers.jam_votes.insufficient_rights')
       redirect_to jam_profile_path(@jam) and return
     end
   end

--- a/app/controllers/jam_votes_controller.rb
+++ b/app/controllers/jam_votes_controller.rb
@@ -22,12 +22,12 @@ class JamVotesController < ApplicationController
     vote_type = default_vote_type if vote_type.blank?
 
     if vote_type == "jury" && !@jam.can_vote_as_jury?(current_user)
-      flash[:failure] = "Недостаточно прав для голосования жюри"
+      flash[:failure] = t('controllers.jam_votes.insufficient_rights_jury')
       return redirect_to new_jam_game_vote_path(@jam, @game)
     end
 
     if vote_type == "audience" && !@jam.can_vote_as_audience?(current_user)
-      flash[:failure] = "Недостаточно прав для голосования аудитории"
+      flash[:failure] = t('controllers.jam_votes.insufficient_rights_audience')
       return redirect_to new_jam_game_vote_path(@jam, @game)
     end
 
@@ -56,7 +56,7 @@ class JamVotesController < ApplicationController
       end
     end
 
-    flash[:success] = "Оценки сохранены"
+    flash[:success] = t('controllers.jam_votes.scores_saved')
     redirect_to game_profile_path(@game, jam_id: @jam.id)
   rescue ActiveRecord::RecordInvalid => e
     flash[:failure] ||= []
@@ -73,28 +73,28 @@ class JamVotesController < ApplicationController
 
   def authorize_vote!
     unless @jam.jam_submissions.where(game_id: @game.id).exists?
-      flash[:failure] = "Эта игра не участвует в данном джеме"
+      flash[:failure] = t('controllers.jam_votes.not_in_jam')
       redirect_to jam_profile_path(@jam) and return
     end
 
     if @game.author == current_user
-      flash[:failure] = "Нельзя оценивать собственную игру"
+      flash[:failure] = t('controllers.jam_votes.own_game')
       redirect_to game_profile_path(@game, jam_id: @jam.id) and return
     end
 
     unless @jam.voting_open?
-      flash[:failure] = "Голосование сейчас закрыто"
+      flash[:failure] = t('controllers.jam_votes.voting_closed')
       redirect_to jam_profile_path(@jam) and return
     end
 
     setting = @jam.rating_setting
     unless setting.jury_enabled || setting.audience_enabled
-      flash[:failure] = "Голосование отключено"
+      flash[:failure] = t('controllers.jam_votes.voting_disabled')
       redirect_to jam_profile_path(@jam) and return
     end
 
     unless @jam.can_vote_as_jury?(current_user) || @jam.can_vote_as_audience?(current_user)
-      flash[:failure] = "Недостаточно прав для голосования"
+      flash[:failure] = t('controllers.jam_votes.insufficient_rights')
       redirect_to jam_profile_path(@jam) and return
     end
   end

--- a/app/controllers/jams_controller.rb
+++ b/app/controllers/jams_controller.rb
@@ -137,7 +137,7 @@ class JamsController < ApplicationController
     elsif @jam.save
       admins = User.where(role: [1, 2])
       admins.each do |admin|
-        current_user.create_notification(admin, current_user, 'awaiting jam moderation', @jam)
+        current_user.create_notification(admin, current_user, 'awaiting_jam_moderation', @jam)
       end
       flash[:success] ||= []
       flash[:success] << t('jams.create.success')
@@ -184,7 +184,7 @@ class JamsController < ApplicationController
     elsif @jam.update(jam_params)
       admins = User.where(role: [1, 2])
       admins.each do |admin|
-        current_user.create_notification(admin, current_user, 'awaiting jam moderation', @jam)
+        current_user.create_notification(admin, current_user, 'awaiting_jam_moderation', @jam)
       end
       @jam.update(status: 0)
       flash[:success] = t('controllers.jams.update_resubmitted')

--- a/app/controllers/jams_controller.rb
+++ b/app/controllers/jams_controller.rb
@@ -29,9 +29,9 @@ class JamsController < ApplicationController
     unless JamSubmission.where(jam_id: params[:id]).find_by(user_id: current_user.id).present?
       jsb = JamSubmission.new(game_id: nil, jam_id: params[:id], user: current_user)
       if jsb.save
-        flash[:notice] = "Вы успешно присоединились к джему!"
+        flash[:notice] = t('controllers.jams.participate_success')
       else
-        flash[:alert] = "Произошла ошибка. Попробуйте еще раз."
+        flash[:alert] = t('controllers.jams.participate_failure')
       end
     end
     redirect_to jam_profile_path(params[:id])
@@ -120,7 +120,7 @@ class JamsController < ApplicationController
     end
     return unless @jam.status != 1 && current_user != @jam.author
 
-    flash[:failure] = 'Джем находится на модерации'
+    flash[:failure] = t('controllers.jams.moderation_pending')
     redirect_to dashboard_path
   end
 
@@ -187,7 +187,7 @@ class JamsController < ApplicationController
         current_user.create_notification(admin, current_user, 'awaiting jam moderation', @jam)
       end
       @jam.update(status: 0)
-      flash[:success] = 'Джем обновлен и отправлен на повторную модерацию!'
+      flash[:success] = t('controllers.jams.update_resubmitted')
       redirect_to jam_profile_path
     else
       flash[:failure] ||= []
@@ -210,9 +210,9 @@ class JamsController < ApplicationController
   def remove_participant
     submission = @jam.jam_submissions.find_by(user_id: params[:user_id])
     if submission&.destroy
-      flash[:notice] = "Участник удалён из джема."
+      flash[:notice] = t('controllers.jams.participant_removed')
     else
-      flash[:alert] = "Не удалось удалить участника."
+      flash[:alert] = t('controllers.jams.participant_remove_failed')
     end
     redirect_to jam_show_participants_path(@jam)
   end
@@ -220,9 +220,9 @@ class JamsController < ApplicationController
   def remove_project
     submission = @jam.jam_submissions.find_by(game_id: params[:game_id])
     if submission&.update(game_id: nil)
-      flash[:notice] = "Проект отвязан от джема."
+      flash[:notice] = t('controllers.jams.project_unlinked')
     else
-      flash[:alert] = "Не удалось удалить проект."
+      flash[:alert] = t('controllers.jams.project_unlink_failed')
     end
     redirect_to jam_show_projects_path(@jam)
   end
@@ -240,7 +240,7 @@ class JamsController < ApplicationController
 
     # 1) сохраняем тумблеры
     if @setting.locked
-      flash[:failure] = "Настройки заблокированы"
+      flash[:failure] = t('controllers.jams.settings_locked')
       return redirect_to rating_settings_jam_path(@jam)
     end
 
@@ -341,7 +341,7 @@ class JamsController < ApplicationController
     end
 
     if @setting.save
-      flash[:success] = "Настройки оценок сохранены"
+      flash[:success] = t('controllers.jams.ratings_saved')
     else
       flash[:failure] ||= []
       flash[:failure] += @setting.errors.full_messages
@@ -363,7 +363,7 @@ class JamsController < ApplicationController
     user = User.find_by(id: params[:user_id])
 
     unless user
-      flash[:failure] = ["Пользователь не найден"]
+      flash[:failure] = [t('controllers.jams.user_not_found')]
       return redirect_to jury_settings_jam_path(@jam)
     end
 
@@ -374,7 +374,7 @@ class JamsController < ApplicationController
     if contributor.save
       current_user.create_notification(user, current_user, "sent_jam_jury_invite", contributor)
       flash[:success] ||= []
-      flash[:success] << "Инвайт отправлен"
+      flash[:success] << t('controllers.jams.invite_sent')
     else
       flash[:failure] ||= []
       flash[:failure] += contributor.errors.full_messages
@@ -405,16 +405,16 @@ class JamsController < ApplicationController
   def accept_contributor_invite
     contributor = @jam.jam_contributors.find_by(id: params[:contributor_id], user_id: current_user.id)
     unless contributor
-      flash[:failure] = "Инвайт не найден"
+      flash[:failure] = t('controllers.jams.invite_not_found')
       return redirect_to jam_profile_path(@jam)
     end
 
     if contributor.update(status: "accepted")
       # нотифицируем автора джема
       current_user.create_notification(@jam.author, current_user, "accepted_jam_jury_invite", contributor)
-      flash[:success] = "Вы приняли приглашение"
+      flash[:success] = t('controllers.jams.invite_accepted')
     else
-      flash[:failure] = "Не удалось принять приглашение"
+      flash[:failure] = t('controllers.jams.invite_accept_failed')
     end
 
     redirect_to jam_profile_path(@jam)
@@ -424,7 +424,7 @@ class JamsController < ApplicationController
     contributor = @jam.jam_contributors.find(params[:contributor_id])
 
     if contributor.update(contributor_params)
-      flash.now[:success] = "Роли обновлены"
+      flash.now[:success] = t('controllers.jams.roles_updated')
     else
       flash.now[:failure] ||= []
       flash.now[:failure] += contributor.errors.full_messages
@@ -454,7 +454,7 @@ class JamsController < ApplicationController
       end
     end
 
-    flash.now[:success] = "Роли обновлены"
+    flash.now[:success] = t('controllers.jams.roles_updated')
     @contributors = @jam.jam_contributors.includes(:user).order(:created_at)
 
     respond_to do |format|
@@ -474,7 +474,7 @@ class JamsController < ApplicationController
   def remove_contributor
     contributor = @jam.jam_contributors.find(params[:contributor_id])
     contributor.destroy
-    flash[:success] = "Удалено"
+    flash[:success] = t('controllers.jams.contributor_removed')
     redirect_to jury_settings_jam_path(@jam)
   end
 
@@ -501,7 +501,7 @@ class JamsController < ApplicationController
   def update_nomination_winner
     set_jam
     unless @jam.can_configure?(current_user)
-      flash[:failure] = ["Недостаточно прав"]
+      flash[:failure] = [t('controllers.application.insufficient_rights')]
       return redirect_to rating_settings_jam_path(@jam), status: :see_other
     end
 
@@ -513,13 +513,13 @@ class JamsController < ApplicationController
     if winner_id.present?
       allowed_game_ids = @jam.submitted_game_ids
       unless allowed_game_ids.include?(winner_id.to_i)
-        flash.now[:failure] = ["Игра не участвует в этом джеме"]
+        flash.now[:failure] = [t('controllers.jams.game_not_in_jam')]
         return respond_winner_update(nomination)
       end
     end
 
     nomination.update!(winner_game_id: winner_id)
-    flash.now[:success] = "Победитель сохранён"
+    flash.now[:success] = t('controllers.jams.winner_saved')
 
     respond_winner_update(nomination)
   rescue ActiveRecord::RecordInvalid => e
@@ -547,7 +547,7 @@ class JamsController < ApplicationController
 
   def author_or_admin
     unless current_user && (current_user == @jam.author || current_user.role.in?([1, 2]))
-      flash[:failure] = "Недостаточно прав"
+      flash[:failure] = t('controllers.application.insufficient_rights')
       redirect_to dashboard_path
     end
   end
@@ -555,7 +555,7 @@ class JamsController < ApplicationController
   def root_check
     return if current_user.jams.find_by_id(params[:id])
 
-    flash[:failure] = 'Недостаточно прав'
+    flash[:failure] = t('controllers.application.insufficient_rights')
     redirect_to dashboard_path
   end
 
@@ -584,25 +584,25 @@ class JamsController < ApplicationController
     deadline = Date.parse(params[:jam][:deadline])
     endDate = Date.parse(params[:jam][:end_date])
 
-    deadline < startDate ? failures.push("Дата сдачи работ не может быть раньше даты начала") : failures
-    endDate < deadline ? failures.push("Дата окончания джема не может быть раньше даты сдачи работ") : failures
-    startDate.year < 2000 ? failures.push("Некорректная дата начала джема") : failures
-    deadline.year < 2000 ? failures.push("Некорректная дата сдачи работ") : failures
-    endDate.year < 2000 ? failures.push("Некорректная дата окончания джема") : failures
+    deadline < startDate ? failures.push(t('controllers.jams.date_deadline_before_start')) : failures
+    endDate < deadline ? failures.push(t('controllers.jams.date_end_before_deadline')) : failures
+    startDate.year < 2000 ? failures.push(t('controllers.jams.date_invalid_start')) : failures
+    deadline.year < 2000 ? failures.push(t('controllers.jams.date_invalid_deadline')) : failures
+    endDate.year < 2000 ? failures.push(t('controllers.jams.date_invalid_end')) : failures
 
     failures
   end
 
   def jam_manage_check
     unless @jam.can_manage?(current_user)
-      flash[:failure] = "Недостаточно прав"
+      flash[:failure] = t('controllers.application.insufficient_rights')
       redirect_to dashboard_path
     end
   end
 
   def jam_configure_check
     unless @jam.can_configure?(current_user)
-      flash[:failure] = "Недостаточно прав"
+      flash[:failure] = t('controllers.application.insufficient_rights')
       redirect_to dashboard_path
     end
   end
@@ -620,7 +620,7 @@ class JamsController < ApplicationController
 
     return if jam.submission_open?
 
-    flash[:failure] = "Приём работ завершён"
+    flash[:failure] = t('controllers.jams.submission_closed')
     redirect_to jam_profile_path(jam)
   end
 end

--- a/app/controllers/moderator/games_controller.rb
+++ b/app/controllers/moderator/games_controller.rb
@@ -22,7 +22,7 @@ module Moderator
         flash[:success] = t('controllers.moderator.games.updated')
         if old_game.status != @game.status
           @author = @game.author
-          @author.create_notification(@author, current_user, 'game change status after moderation', @game)
+          @author.create_notification(@author, current_user, 'game_status_changed', @game)
         end
 
         changes = @game.previous_changes.except('updated_at')

--- a/app/controllers/moderator/games_controller.rb
+++ b/app/controllers/moderator/games_controller.rb
@@ -19,7 +19,7 @@ module Moderator
       params[:game][:reason] = nil if params[:game][:status].to_i != 2
 
       if @game.update(game_params)
-        flash[:success] = 'Игра успешно обновлена'
+        flash[:success] = t('controllers.moderator.games.updated')
         if old_game.status != @game.status
           @author = @game.author
           @author.create_notification(@author, current_user, 'game change status after moderation', @game)
@@ -36,7 +36,7 @@ module Moderator
 
     def destroy
       create_administration_record(current_user, @game, {}, 'delete') if @game.destroy
-      flash[:success] = 'Игра успешно удалена'
+      flash[:success] = t('controllers.moderator.games.deleted')
       redirect_to moderator_games_path
     end
 

--- a/app/controllers/moderator/jams_controller.rb
+++ b/app/controllers/moderator/jams_controller.rb
@@ -22,7 +22,7 @@ module Moderator
         flash[:success] = t('controllers.moderator.jams.updated')
         if old_jam.status != @jam.status
           @author = @jam.author
-          @author.create_notification(@author, current_user, 'jam change status after moderation', @jam)
+          @author.create_notification(@author, current_user, 'jam_status_changed', @jam)
         end
 
         changes = @jam.previous_changes.except('updated_at')

--- a/app/controllers/moderator/jams_controller.rb
+++ b/app/controllers/moderator/jams_controller.rb
@@ -19,7 +19,7 @@ module Moderator
       params[:jam][:reason] = nil if params[:jam][:status].to_i != 2
 
       if @jam.update(jam_params)
-        flash[:success] = 'Джем успешно обновлен'
+        flash[:success] = t('controllers.moderator.jams.updated')
         if old_jam.status != @jam.status
           @author = @jam.author
           @author.create_notification(@author, current_user, 'jam change status after moderation', @jam)
@@ -36,7 +36,7 @@ module Moderator
 
     def destroy
       create_administration_record(current_user, @jam, {}, 'delete') if @jam.destroy
-      flash[:success] = 'Джем успешно удален'
+      flash[:success] = t('controllers.moderator.jams.deleted')
       redirect_to moderator_jams_path
     end
 

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -7,13 +7,13 @@ class PasswordResetsController < ApplicationController
     @user = User.find_by_email(params[:email])
     if @user.present?
       @user.set_password_reset_token
-      PasswordResetMailer.with(user: @user).reset_email.deliver_later
+      PasswordResetMailer.with(user: @user, locale: I18n.locale).reset_email.deliver_later
       flash[:success] ||= []
-      flash[:success] << 'Инструкции были отправлены на ваш адрес'
+      flash[:success] << t('controllers.password_resets.instructions_sent')
       redirect_to login_path
     else
       flash[:failure] ||= []
-      flash[:failure] << 'Не найдена указанная почта'
+      flash[:failure] << t('controllers.password_resets.email_not_found')
       redirect_to password_reset_path
     end
   end
@@ -23,33 +23,33 @@ class PasswordResetsController < ApplicationController
   def update
      if user_params[:password].blank? || user_params[:password_confirmation].blank?
        flash[:failure] ||= []
-       flash[:failure] << "All fields must be filled in"
-       redirect_to request.fullpath # Пока такой костыль
+       flash[:failure] << t('controllers.password_resets.fields_blank')
+       redirect_to request.fullpath
        return
      elsif user_params[:password].length < 5
        flash[:failure] ||= []
-       flash[:failure] << "New password is too short (minimum is 5 characters)."
-       redirect_to request.fullpath # Пока такой костыль
+       flash[:failure] << t('controllers.password_resets.too_short')
+       redirect_to request.fullpath
        return
      elsif user_params[:password] != user_params[:password_confirmation]
        flash[:failure] ||= []
-       flash[:failure] << "New passwords do not match."
-       redirect_to request.fullpath # Пока такой костыль
+       flash[:failure] << t('controllers.password_resets.no_match')
+       redirect_to request.fullpath
        return
      elsif user_params[:password] == params[:user][:current_password]
        flash[:failure] ||= []
-       flash[:failure] << "New password must be different from the old one."
-       redirect_to request.fullpath # Пока такой костыль
+       flash[:failure] << t('controllers.password_resets.same_as_old')
+       redirect_to request.fullpath
        return
      end
 
      if @user.update(user_params)
        flash[:success] ||= []
-       flash[:success] << "Пароль успешно обновлен!"
+       flash[:success] << t('controllers.password_resets.success')
        redirect_to login_path
      else
        flash[:failure] ||= []
-       flash[:failure] << "Что-то пошло не так!"
+       flash[:failure] << t('controllers.password_resets.failure')
        redirect_to login_path
      end
   end
@@ -63,7 +63,7 @@ class PasswordResetsController < ApplicationController
   def check_user_params
     if params[:user].blank?
       flash[:failure] ||= []
-      flash[:failure] << "Что-то пошло не так!"
+      flash[:failure] << t('controllers.password_resets.failure')
       redirect_to(login_path)
     end
   end
@@ -73,7 +73,7 @@ class PasswordResetsController < ApplicationController
     @user = nil unless @user.authenticate_password_reset_token(params[:user][:password_reset_token])
     unless @user&.password_reset_period_valid?
       flash[:failure] ||= []
-      flash[:failure] << "Токен недействителен!"
+      flash[:failure] << t('controllers.password_resets.invalid_token')
       redirect_to login_path
     end
   end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -20,10 +20,8 @@ class ReportsController < ApplicationController
   end
 
   def notify_admins(report)
-    admins = User.where(role: [1, 2])
-    message = t('controllers.reports.notification', type: report.reportable_type, id: report.reportable_id)
-    admins.each do |admin|
-      current_user.create_notification(admin, current_user, message, report)
+    User.where(role: [1, 2]).find_each do |admin|
+      current_user.create_notification(admin, current_user, 'new_report', report)
     end
   end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -6,9 +6,9 @@ class ReportsController < ApplicationController
 
     if @report.save
       notify_admins(@report)
-      render json: { message: 'Жалоба успешно отправлена' }, status: :ok
+      render json: { message: t('controllers.reports.sent') }, status: :ok
     else
-      render json: { error: @report.errors[:reportable_id].first || @report.errors.full_messages.to_sentence }, 
+      render json: { error: @report.errors[:reportable_id].first || @report.errors.full_messages.to_sentence },
              status: :unprocessable_entity
     end
   end
@@ -21,9 +21,9 @@ class ReportsController < ApplicationController
 
   def notify_admins(report)
     admins = User.where(role: [1, 2])
+    message = t('controllers.reports.notification', type: report.reportable_type, id: report.reportable_id)
     admins.each do |admin|
-      current_user.create_notification(admin, current_user,
-                                       "Новая жалоба на #{report.reportable_type} с id #{report.reportable_id}", report)
+      current_user.create_notification(admin, current_user, message, report)
     end
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -22,17 +22,16 @@ class SessionsController < ApplicationController
         redirect_to dashboard_path
       elsif !user.email_confirm_period_valid? && user.last_active_at.nil? && user.last_seen_at.nil?
         user.destroy
-        flash[:failure] =
-          'Ваш аккаунт был удален из-за истечения срока действия токена. Пожалуйста, зарегистрируйтесь снова.'
+        flash[:failure] = t('controllers.sessions.account_token_expired')
         redirect_to login_path
       else
         if user.email_confirm_period_valid?
-          flash[:success] = 'Письмо с кодом для входа уже было отправлено на вашу почту'
+          flash[:success] = t('controllers.sessions.email_letter_sent')
         else
           @token = user.set_email_confirm_token
-          EmailConfirmMailer.with(user: user, token: @token).email_confirm.deliver_later
+          EmailConfirmMailer.with(user: user, token: @token, locale: I18n.locale).email_confirm.deliver_later
           flash[:success] ||= []
-        flash[:success] << 'Инструкции были отправлены на ваш адрес'
+        flash[:success] << t('controllers.sessions.instructions_sent')
         end
         redirect_to edit_email_confirm_url(user: { email_confirm_token: user.email_confirm_token,
                                                    email: user.email }).gsub('&amp;', '&')
@@ -82,13 +81,13 @@ class SessionsController < ApplicationController
     user = User.find(params[:user])
     session_ids = user.sessions.pluck(:id)
     if user.sessions.destroy_all
-      flash[:success] = 'Все сессии успешно удалены'
+      flash[:success] = t('controllers.sessions.all_sessions_logged_out')
       if user != current_user
         create_administration_record(current_user, user, { 'session_ids' => session_ids },
                                      'delete')
       end
     else
-      flash[:failure] = 'Не удалось удалить сессии'
+      flash[:failure] = t('controllers.sessions.sessions_logout_failed')
     end
     redirect_to edit_admin_user_path(user)
   end
@@ -98,10 +97,10 @@ class SessionsController < ApplicationController
     user_session = user.sessions.find_by(id: params[:session_id])
 
     if user_session&.destroy
-      flash[:success] = 'Сессия успешно удалена'
+      flash[:success] = t('controllers.sessions.session_logged_out')
       create_administration_record(current_user, user, { 'session_id' => user_session.id }, 'delete') if user != current_user
     else
-      flash[:failure] = 'Не удалось удалить сессию'
+      flash[:failure] = t('controllers.sessions.session_logout_failed')
     end
     redirect_to edit_admin_user_path(user)
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -28,9 +28,9 @@ class UsersController < ApplicationController
 
     if @user.save
       @token = @user.set_email_confirm_token
-      EmailConfirmMailer.with(user: @user, token: @token).email_confirm.deliver_later
+      EmailConfirmMailer.with(user: @user, token: @token, locale: I18n.locale).email_confirm.deliver_later
       flash[:success] ||= []
-      flash[:success] << 'Инструкции были отправлены на ваш адрес'
+      flash[:success] << t('controllers.users.instructions_sent')
       redirect_to edit_email_confirm_url(user: { email_confirm_token: @user.email_confirm_token,
                                                  email: @user.email }).gsub('&amp;', '&')
     else
@@ -49,7 +49,7 @@ class UsersController < ApplicationController
       render json: { success: true }, status: :ok
     else
       flash[:error] = t 'users.destroy.error'
-      render json: { success: false, error: 'Неверный пароль.' }, status: :unprocessable_entity
+      render json: { success: false, error: t('controllers.users.invalid_password') }, status: :unprocessable_entity
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,25 +18,15 @@ module ApplicationHelper
   end
 
   def notification_message(notification)
-    case notification.action
-    when 'accepted_friendship'
-      'принял заявку в друзья'
-    when 'sent_friend_request'
-      'отправил запрос в друзья'
-    when 'awaiting game moderation'
-      '- игра ожидает модерацию'
-    when 'awaiting jam moderation'
-      '- джем ожидает модерацию'
-    when 'game change status after moderation'
-      '- статус игры изменен после модерации'
-    when 'jam change status after moderation'
-      '- статус джема изменен после модерации'
-    when 'sent_jam_jury_invite'
-      'пригласил вас в жюри'
-    when 'accepted_jam_jury_invite'
-      'принял приглашение в жюри'
-    else
-      notification.action
-    end
+    return '' if notification.blank? || notification.action.blank?
+
+    key = notification.action.to_s.strip.downcase.tr(' ', '_')
+
+    I18n.t(
+      "notifications.actions.#{key}",
+      type: notification.notifiable_type,
+      id: notification.notifiable_id,
+      default: notification.action
+    )
   end
 end

--- a/app/javascript/controllers/autosubmit_controller.js
+++ b/app/javascript/controllers/autosubmit_controller.js
@@ -1,7 +1,10 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-    static values = { delay: { type: Number, default: 400 } }
+    static values = {
+        delay: { type: Number, default: 400 },
+        tooShort: String
+    }
 
     connect() {
         this.timeout = null
@@ -13,10 +16,9 @@ export default class extends Controller {
         const input = event.target
         const query = input.value.trim()
 
-        // ❗ Не искать если меньше 2 символов
         if (query.length < 2) {
             document.getElementById("jury_search_results").innerHTML =
-                '<div class="mt-3 text-sm text-gray-500">Введите минимум 2 символа</div>'
+                `<div class="mt-3 text-sm text-gray-500">${this.tooShortValue}</div>`
             return
         }
 

--- a/app/javascript/controllers/freeze_controller.js
+++ b/app/javascript/controllers/freeze_controller.js
@@ -2,6 +2,12 @@ import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
     static targets = ["reason", "duration", "submit"];
+    static values = {
+        reasonRequired: String,
+        freezing: String,
+        error: String,
+        freezeLabel: String
+    };
 
     connect() {
         this.toggleButton();
@@ -34,12 +40,12 @@ export default class extends Controller {
         const duration = this.durationTarget.value;
 
         if (!reason) {
-            alert("Необходимо указать причину заморозки.");
+            alert(this.reasonRequiredValue);
             return;
         }
 
         this.submitTarget.setAttribute("disabled", "true");
-        this.submitTarget.textContent = "Замораживание...";
+        this.submitTarget.textContent = this.freezingValue;
 
         const response = await fetch(`/admin/users/${this.element.dataset.userId}/freeze`, {
             method: "POST",
@@ -53,9 +59,9 @@ export default class extends Controller {
         if (response.ok) {
             location.reload();
         } else {
-            alert("Ошибка при заморозке пользователя.");
+            alert(this.errorValue);
             this.submitTarget.removeAttribute("disabled");
-            this.submitTarget.textContent = "Заморозить";
+            this.submitTarget.textContent = this.freezeLabelValue;
         }
     }
 }

--- a/app/javascript/controllers/jams_controller.js
+++ b/app/javascript/controllers/jams_controller.js
@@ -8,6 +8,12 @@ export default class extends Controller {
         "checkbox", "label", "allJams", "myJams", "showAll", "showMine", "searchForm"
     ]
 
+    static values = {
+        invalidDates: String,
+        deadlineBeforeStart: String,
+        endBeforeDeadline: String
+    }
+
     connect() {
         this.timeout = null;
         this.displayAllJams();
@@ -126,7 +132,7 @@ export default class extends Controller {
         const startDate = this._parseDate(startDateInput.value);
 
         if (!startDate || startDate.getFullYear() < 2000) {
-            errorMessageElement.textContent = 'Пожалуйста, введите корректные даты';
+            errorMessageElement.textContent = this.invalidDatesValue;
         } else {
             errorMessageElement.textContent = '';
         }
@@ -151,9 +157,9 @@ export default class extends Controller {
         const deadline = this._parseDate(deadlineInput.value);
 
         if (!deadline || deadline.getFullYear() < 2000) {
-            errorMessageElement.textContent = 'Пожалуйста, введите корректные даты';
+            errorMessageElement.textContent = this.invalidDatesValue;
         } else if (deadline < startDate) {
-            errorMessageElement.textContent = 'Дата сдачи работ не может быть раньше даты начала';
+            errorMessageElement.textContent = this.deadlineBeforeStartValue;
         } else {
             errorMessageElement.textContent = '';
         }
@@ -177,9 +183,9 @@ export default class extends Controller {
         const endDate = this._parseDate(endDateInput.value);
 
         if (!endDate || endDate.getFullYear() < 2000) {
-            errorMessageElement.textContent = 'Пожалуйста, введите корректные даты';
+            errorMessageElement.textContent = this.invalidDatesValue;
         } else if (endDate < deadline) {
-            errorMessageElement.textContent = 'Дата окончания джема не может быть раньше даты сдачи работ';
+            errorMessageElement.textContent = this.endBeforeDeadlineValue;
         } else {
             errorMessageElement.textContent = '';
         }

--- a/app/javascript/controllers/report_controller.js
+++ b/app/javascript/controllers/report_controller.js
@@ -2,6 +2,12 @@ import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
     static targets = ["modal", "successModal", "errorModal", "errorMessage", "textarea", "warning"];
+    static values = {
+        submitting: String,
+        otherReason: String,
+        genericError: String,
+        submit: String
+    };
 
     open() {
         this.modalTarget.classList.remove("hidden");
@@ -26,13 +32,13 @@ export default class extends Controller {
         const submitButton = form.querySelector("button[type='submit']");
 
         submitButton.disabled = true;
-        submitButton.textContent = "Отправка...";
+        submitButton.textContent = this.submittingValue;
 
         const payload = {
             report: {
                 reportable_type: data.get("reportable_type"),
                 reportable_id: data.get("reportable_id"),
-                reason: data.get("reason") || "Другая причина",
+                reason: data.get("reason") || this.otherReasonValue,
                 comment: data.get("complaint"),
             }
         };
@@ -51,7 +57,7 @@ export default class extends Controller {
                     this.close();
                     this.successModalTarget.classList.remove("hidden");
                 } else {
-                    throw new Error(body.error || "Произошла ошибка при отправке жалобы");
+                    throw new Error(body.error || this.genericErrorValue);
                 }
             })
             .catch((error) => {
@@ -59,7 +65,7 @@ export default class extends Controller {
             })
             .finally(() => {
                 submitButton.disabled = false;
-                submitButton.textContent = "Отправить";
+                submitButton.textContent = this.submitValue;
             });
     }
 

--- a/app/javascript/controllers/unfreeze_controller.js
+++ b/app/javascript/controllers/unfreeze_controller.js
@@ -2,6 +2,7 @@ import { Controller } from "stimulus";
 
 export default class extends Controller {
     static targets = ["submit"];
+    static values = { error: String };
 
     async unfreezeUser() {
         const response = await fetch(`/admin/users/${this.element.dataset.userId}/unfreeze`, {
@@ -15,7 +16,7 @@ export default class extends Controller {
         if (response.ok) {
             location.reload();
         } else {
-            alert("Ошибка при разморозке пользователя.");
+            alert(this.errorValue);
         }
     }
 }

--- a/app/javascript/controllers/visits_controller.js
+++ b/app/javascript/controllers/visits_controller.js
@@ -3,6 +3,12 @@ import Chart from "chart.js/auto";
 
 export default class extends Controller {
     static targets = ["chart"];
+    static values = {
+        activeUsersLabel: String,
+        registeredUsersLabel: String,
+        userCountLabel: String,
+        dateLabel: String
+    };
 
     connect() {
         this.fetchData(30);
@@ -41,14 +47,14 @@ export default class extends Controller {
                 labels: dates,
                 datasets: [
                     {
-                        label: "Активные пользователи",
+                        label: this.activeUsersLabelValue,
                         data: visits,
                         borderColor: "rgba(75, 192, 192, 1)",
                         backgroundColor: "rgba(75, 192, 192, 0.2)",
                         fill: true,
                     },
                     {
-                        label: "Зарегистрированные пользователи",
+                        label: this.registeredUsersLabelValue,
                         data: registrationCounts,
                         borderColor: "rgba(153, 102, 255, 1)",
                         backgroundColor: "rgba(153, 102, 255, 0.2)",
@@ -63,7 +69,7 @@ export default class extends Controller {
                         beginAtZero: true,
                         title: {
                             display: true,
-                            text: 'Количество пользователей'
+                            text: this.userCountLabelValue
                         },
                         ticks: {
                             callback: function(value) {
@@ -74,7 +80,7 @@ export default class extends Controller {
                     x: {
                         title: {
                             display: true,
-                            text: 'Дата'
+                            text: this.dateLabelValue
                         }
                     }
                 }

--- a/app/mailers/email_confirm_mailer.rb
+++ b/app/mailers/email_confirm_mailer.rb
@@ -1,8 +1,12 @@
 class EmailConfirmMailer < ActionMailer::Base
   default from: 'jammer.website@internet.ru'
+
   def email_confirm
     @user = params[:user]
     @token = params[:token]
-    mail to: @user.email, subject: 'Confirm email | Jammer'
+    locale = params[:locale] || I18n.locale
+    I18n.with_locale(locale) do
+      mail to: @user.email, subject: t('mailers.email_confirm.subject')
+    end
   end
 end

--- a/app/mailers/password_reset_mailer.rb
+++ b/app/mailers/password_reset_mailer.rb
@@ -1,7 +1,11 @@
 class PasswordResetMailer < ActionMailer::Base
   default from: 'jammer.website@internet.ru'
+
   def reset_email
     @user = params[:user]
-    mail to: @user.email, subject: 'Reset password | Jammer'
+    locale = params[:locale] || I18n.locale
+    I18n.with_locale(locale) do
+      mail to: @user.email, subject: t('mailers.password_reset.subject')
+    end
   end
 end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,7 +1,7 @@
 class Game < ActiveRecord::Base
   validates :name, :description, presence: true
-  validates :cover, presence: { message: "Обложка обязательна для загрузки" }
-  validates :game_file, presence: { message: "Файл игры обязателен для загрузки" }
+  validates :cover, presence: true
+  validates :game_file, presence: true
 
   has_one_attached :cover
   has_one_attached :game_file
@@ -15,26 +15,23 @@ class Game < ActiveRecord::Base
 
   has_and_belongs_to_many :tags
 
-  validates_length_of :tags, maximum: 10, message: 'Можно выбрать не более 10 тегов'
+  validates_length_of :tags, maximum: 10
 
   validate :game_file_format
   validate :game_file_size
   def jam_rating(jam_id, vote_type: nil)
-    # 1) Оценки звёздами (voted_on)
     reviews_scope = reviews.where(jam_id: jam_id).where.not(user_mark: 0)
 
     if vote_type.present?
-      vt = Review.vote_types[vote_type.to_s] # "jury"/"audience" -> int
+      vt = Review.vote_types[vote_type.to_s]
       reviews_scope = reviews_scope.where(vote_type: vt) if vt
     end
 
     reviews_sum = reviews_scope.sum(:user_mark)
     reviews_cnt = reviews_scope.count
 
-    # 2) “1 голос за игру” (manually_ranked) -> считаем как 5 звёзд
     picks_scope = JamCriterionPick.where(jam_id: jam_id, game_id: id)
 
-    # если хочешь учитывать только конкретный канал (jury/audience) — фильтруем
     if vote_type.present? && %w[jury audience].include?(vote_type.to_s)
       picks_scope = picks_scope.where(channel: vote_type.to_s)
     end
@@ -62,7 +59,7 @@ class Game < ActiveRecord::Base
     if game_file.attached?
       acceptable_types = %w[application/zip application/x-rar-compressed application/x-7z-compressed]
       unless acceptable_types.include?(game_file.content_type)
-        errors.add(:game_file, "Файл должен быть в формате .zip, .rar или .7z")
+        errors.add(:game_file, :wrong_format)
       end
     end
   end
@@ -70,7 +67,7 @@ class Game < ActiveRecord::Base
 
   def game_file_size
     if game_file.attached? && game_file.byte_size > 100.megabytes
-      errors.add(:game_file, "Размер архива не должен превышать 100 MB")
+      errors.add(:game_file, :too_large)
     end
   end
 end

--- a/app/models/jam.rb
+++ b/app/models/jam.rb
@@ -1,7 +1,7 @@
 class Jam < ActiveRecord::Base
   validates :name, :start_date, :deadline, :end_date, presence: true
-  validates :cover, presence: { message: "Обложка обязательна для загрузки" }
-  validates :logo, presence: { message: "Логотип обязателен для загрузки" }
+  validates :cover, presence: true
+  validates :logo, presence: true
 
   has_rich_text :description
 
@@ -33,7 +33,6 @@ class Jam < ActiveRecord::Base
     jam_contributors.find_by(user_id: user.id, status: "accepted")
   end
 
-  # Операционное управление джемом: edit/update/destroy, remove_participant/remove_project и т.п.
   def can_manage?(user)
     return false unless user
     return true if user == author
@@ -44,7 +43,6 @@ class Jam < ActiveRecord::Base
     jc.host? || jc.admin?
   end
 
-  # "Глобальные настройки" джема: настройки оценок и жюри
   def can_configure?(user)
     return false unless user
     return true if user == author
@@ -52,7 +50,7 @@ class Jam < ActiveRecord::Base
     jc = contributor_record(user)
     return false unless jc
 
-    jc.host? # только host (и автор)
+    jc.host?
   end
 
   def judge?(user)
@@ -102,17 +100,16 @@ class Jam < ActiveRecord::Base
 
   has_and_belongs_to_many :tags
 
-  validates_length_of :tags, maximum: 10, message: 'Можно выбрать не более 10 тегов'
+  validates_length_of :tags, maximum: 10
 
   validates :reason, presence: true, if: -> { status == 2 }
-  validates_length_of :tags, maximum: 10, message: "Можно выбрать не более 10 тегов"
 
   validate :description_presence
 
   private
   def description_presence
     if description.blank? || description.body.blank?
-      errors.add(:description, "Описание обязательно для заполнения")
+      errors.add(:description, :blank)
     end
   end
 end

--- a/app/models/jam_rating_setting.rb
+++ b/app/models/jam_rating_setting.rb
@@ -7,7 +7,7 @@ class JamRatingSetting < ApplicationRecord
 
   def at_least_one_enabled
     if !jury_enabled && !audience_enabled
-      errors.add(:base, "Нельзя выключить и жюри, и аудиторию одновременно")
+      errors.add(:base, :both_disabled)
     end
   end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -3,7 +3,7 @@ class Report < ApplicationRecord
   belongs_to :reportable, polymorphic: true
 
   validates :reason, presence: true
-  validates :reportable_id, uniqueness: { scope: %i[reportable_type reporter_id], message: 'Вы уже отправили жалобу на эту сущность' }
+  validates :reportable_id, uniqueness: { scope: %i[reportable_type reporter_id] }
 
   enum :status, pending: 0, resolved: 1, rejected: 2
 end

--- a/app/views/admin/actions/index.html.erb
+++ b/app/views/admin/actions/index.html.erb
@@ -1,14 +1,14 @@
-<h1 class="text-2xl font-bold mb-6 text-center">Журнал действий администраторов</h1>
+<h1 class="text-2xl font-bold mb-6 text-center"><%= t('.title') %></h1>
 <div class="overflow-x-auto px-4">
   <table class="min-w-full bg-white shadow-md rounded-lg overflow-hidden">
     <thead>
     <tr class="bg-gray-200 text-gray-600 uppercase text-xs md:text-sm">
-      <th class="py-3 px-6 text-left">Администратор</th>
-      <th class="py-3 px-6 text-left">Тип записи</th>
-      <th class="py-3 px-6 text-left">ID объекта записи</th>
-      <th class="py-3 px-6 text-left">Действие</th>
-      <th class="py-3 px-6 text-left">Изменения</th>
-      <th class="py-3 px-6 text-left">Дата</th>
+      <th class="py-3 px-6 text-left"><%= t('.admin') %></th>
+      <th class="py-3 px-6 text-left"><%= t('.record_type') %></th>
+      <th class="py-3 px-6 text-left"><%= t('.record_id') %></th>
+      <th class="py-3 px-6 text-left"><%= t('.action') %></th>
+      <th class="py-3 px-6 text-left"><%= t('.changes') %></th>
+      <th class="py-3 px-6 text-left"><%= t('.date') %></th>
     </tr>
     </thead>
     <tbody>
@@ -22,7 +22,7 @@
           <% changes = action.changed_fields %>
           <% if changes.present? && changes.is_a?(Hash) %>
             <div>
-              <strong>Старые значения:</strong>
+              <strong><%= t('.old_values') %></strong>
               <ul>
                 <% changes['old_attributes'].each do |key, value| %>
                   <li><%= "#{key}: #{value}" %></li>
@@ -30,7 +30,7 @@
               </ul>
             </div>
             <div>
-              <strong>Новые значения:</strong>
+              <strong><%= t('.new_values') %></strong>
               <ul>
                 <% changes['new_attributes'].each do |key, value| %>
                   <li><%= "#{key}: #{value}" %></li>
@@ -38,7 +38,7 @@
               </ul>
             </div>
           <% else %>
-            <span>Нет изменений</span>
+            <span><%= t('.no_changes') %></span>
           <% end %>
         </td>
         <td class="py-3 px-6 text-sm md:text-base"><%= action.created_at.strftime("%Y-%m-%d %H:%M:%S") %></td>

--- a/app/views/admin/games/_form.html.erb
+++ b/app/views/admin/games/_form.html.erb
@@ -1,6 +1,6 @@
 <div class="p-6" data-controller="settings">
   <div class="mt-4">
-    <%= link_to 'Назад', request.referer && URI(request.referer).path != request.fullpath ? URI(request.referer).path : admin_games_path, class: 'bg-gray-300 text-gray-800 py-2 px-4 rounded hover:bg-gray-400' %>
+    <%= link_to t('admin.shared.back'), request.referer && URI(request.referer).path != request.fullpath ? URI(request.referer).path : admin_games_path, class: 'bg-gray-300 text-gray-800 py-2 px-4 rounded hover:bg-gray-400' %>
   </div>
 
   <div>
@@ -31,15 +31,15 @@
                 <%= f.label :status, class: 'block text-sm font-medium text-gray-700' %>
               </div>
               <div class="w-3/4">
-                <p class="text-sm">0 - Модерация; 1 - Одобрено; 2 - Отклонено</p>
+                <p class="text-sm"><%= t('admin.shared.status_hint') %></p>
                 <%= f.select :status, options_for_select([['0', 0], ['1', 1], ['2', 2]], f.object.status),
                              { target: 'status' },
                              class: 'mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50',
                              id: "game_status",
                              data: { action: 'change->status#updateReasonField', status_target: 'status' } %>
                 <div data-status-target="reasonField" style="<%= f.object.status == 2 ? '' : 'display: none;' %>">
-                  <%= f.label :reason, "Причина отклонения", class: 'block text-sm font-medium text-gray-700 mt-2' %>
-                  <%= f.select :reason, [['Непристойный контент', 'Непристойный контент'], ['Реклама', 'Реклама'], ['Плагиат', 'Плагиат']],
+                  <%= f.label :reason, t('admin.shared.rejection_reason'), class: 'block text-sm font-medium text-gray-700 mt-2' %>
+                  <%= f.select :reason, [[t('admin.shared.rejection_reasons.indecent_content'), 'Непристойный контент'], [t('admin.shared.rejection_reasons.advertising'), 'Реклама'], [t('admin.shared.rejection_reasons.plagiarism'), 'Плагиат']],
                                { include_blank: true },
                                class: 'mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50' %>
                 </div>
@@ -49,11 +49,11 @@
 
           <div class="flex items-center">
             <div class="w-1/4">
-              <%= f.label :cover, "Обложка", class: "block text-sm font-medium text-gray-700" %>
+              <%= f.label :cover, t('.cover'), class: "block text-sm font-medium text-gray-700" %>
             </div>
             <div class="w-3/4">
               <label class="block text-sm font-medium text-gray-700 mb-2" for="game_cover">
-                Обложка
+                <%= t('.cover') %>
               </label>
               <%= f.file_field :cover, class: "mt-1 block w-full text-gray-500 file:py-2 file:px-4 file:border file:border-gray-300 file:rounded-md file:bg-gray-100 file:text-sm file:font-medium hover:file:bg-gray-200 focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50" %>
 
@@ -73,20 +73,20 @@
 
           <div class="flex items-center">
             <div class="w-1/4">
-              <%= f.label :game_file, "Файл игры",
+              <%= f.label :game_file, t('.game_file'),
                              class: "block text-sm font-medium text-gray-700" %>
             </div>
             <div class="w-3/4">
               <label class="block text-sm font-medium text-gray-700 mb-2" for="game_game_file">
-                Файл игры
+                <%= t('.game_file') %>
               </label>
               <%= f.file_field :game_file, accept: ".zip,.rar,.7z",
                                class: "mt-1 block w-full text-gray-500 file:py-2 file:px-4 file:border file:border-gray-300 file:rounded-md file:bg-gray-100 file:text-sm file:font-medium hover:file:bg-gray-200 focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50" %>
 
               <% if game.game_file.attached? %>
                 <p class="mt-2 text-sm text-gray-500">
-                  Текущий файл:
-                  <%= link_to "Скачать архив", url_for(@game.game_file),
+                  <%= t('.current_file') %>
+                  <%= link_to t('.download_archive'), url_for(@game.game_file),
                               download: true,
                               class: "text-indigo-600 hover:text-indigo-900 font-medium underline" %>
                 </p>
@@ -96,7 +96,7 @@
 
           <div class="flex items-center">
             <div class="w-1/4">
-              <%= f.label :tags, "Теги", class: "block text-sm font-medium text-gray-700" %>
+              <%= f.label :tags, t('admin.shared.tags'), class: "block text-sm font-medium text-gray-700" %>
             </div>
             <div class="w-3/4">
               <div class="mt-1">
@@ -114,7 +114,7 @@
             <div class="w-1/4"></div>
             <div class="w-3/4">
               <div class="mt-6 flex items-center space-x-2">
-                <%= f.submit 'Сохранить', class: 'bg-green-500 text-white py-2 px-4 rounded hover:bg-green-600' %>
+                <%= f.submit t('admin.shared.save'), class: 'bg-green-500 text-white py-2 px-4 rounded hover:bg-green-600' %>
               </div>
             </div>
           </div>

--- a/app/views/admin/games/_game.html.erb
+++ b/app/views/admin/games/_game.html.erb
@@ -8,7 +8,7 @@
           <%= truncate(game.author.name, length: 15) %>
         </a>
       <% else %>
-        <span>Автор неизвестен</span>
+        <span><%= t('admin.shared.author_unknown') %></span>
       <% end %>
     </td>
     <td class="py-3 px-6 hover:underline">
@@ -17,8 +17,8 @@
     <td class="py-3 px-10"><%= game.status %></td>
     <td class="py-3 px-6"><%= game.created_at.strftime("%Y-%m-%d %H:%M") %></td>
     <td class="py-3 px-6 flex flex-col sm:flex-row space-y-2 sm:space-y-0 sm:space-x-2">
-      <%= link_to 'Edit', edit_admin_game_path(game), class: 'bg-blue-500 text-white py-1 px-3 rounded hover:bg-blue-600' %>
-      <%= link_to 'Delete', admin_game_path(game), class: 'bg-red-500 text-white py-1 px-3 rounded hover:bg-red-600', data: { turbo_method: :delete, turbo_confirm: 'Вы уверены?' } %>
+      <%= link_to t('admin.shared.edit'), edit_admin_game_path(game), class: 'bg-blue-500 text-white py-1 px-3 rounded hover:bg-blue-600' %>
+      <%= link_to t('admin.shared.delete'), admin_game_path(game), class: 'bg-red-500 text-white py-1 px-3 rounded hover:bg-red-600', data: { turbo_method: :delete, turbo_confirm: t('admin.shared.confirm') } %>
     </td>
   </tr>
 <% end %>

--- a/app/views/admin/games/index.html.erb
+++ b/app/views/admin/games/index.html.erb
@@ -3,12 +3,12 @@
     <%= form_with url: admin_games_path, method: :get, class: "pb-4", local: true do |form| %>
       <div class="flex flex-col md:flex-row items-center space-y-2 md:space-y-0 md:space-x-4 w-full">
         <div class="flex items-center w-full md:w-auto">
-          <%= form.label :query, "Поиск игр", class: 'block font-semibold text-gray-700 mr-2' %>
+          <%= form.label :query, t('.search_label'), class: 'block font-semibold text-gray-700 mr-2' %>
           <%= form.text_field :query, value: params[:query], placeholder: '', class: 'border border-gray-300 rounded-lg p-2 text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent w-full' %>
         </div>
         <div class="flex items-center space-x-2 mt-2 md:mt-0">
-          <%= form.submit 'Поиск', class: 'bg-blue-500 text-white font-semibold py-2 px-4 rounded-lg hover:bg-blue-600 transition duration-150 ease-in-out shadow' %>
-          <%= link_to 'Сбросить', admin_games_path, class: 'text-gray-500 hover:text-gray-700 font-semibold' %>
+          <%= form.submit t('admin.shared.search'), class: 'bg-blue-500 text-white font-semibold py-2 px-4 rounded-lg hover:bg-blue-600 transition duration-150 ease-in-out shadow' %>
+          <%= link_to t('admin.shared.reset'), admin_games_path, class: 'text-gray-500 hover:text-gray-700 font-semibold' %>
         </div>
       </div>
     <% end %>
@@ -49,6 +49,6 @@
     </div>
     <%= render partial: 'helpers/pagy' %>
   <% else %>
-    <p class="text-gray-500 m-8">Игры не найдены по запросу "<%= params[:query] %>".</p>
+    <p class="text-gray-500 m-8"><%= t('.not_found', query: params[:query]) %></p>
   <% end %>
 </div>

--- a/app/views/admin/jams/_form.html.erb
+++ b/app/views/admin/jams/_form.html.erb
@@ -1,6 +1,6 @@
 <div class="p-6" data-controller="settings">
   <div class="mt-4">
-    <%= link_to 'Назад', request.referer && URI(request.referer).path != request.fullpath ? URI(request.referer).path : admin_jams_path, class: 'bg-gray-300 text-gray-800 py-2 px-4 rounded hover:bg-gray-400' %>
+    <%= link_to t('admin.shared.back'), request.referer && URI(request.referer).path != request.fullpath ? URI(request.referer).path : admin_jams_path, class: 'bg-gray-300 text-gray-800 py-2 px-4 rounded hover:bg-gray-400' %>
   </div>
 
   <div>
@@ -27,7 +27,7 @@
 
           <div class="flex items-center">
             <div class="w-1/4">
-              <%= f.label :start_date, "Дата начала", class: "block text-sm font-medium text-gray-700" %>
+              <%= f.label :start_date, t('.start_date'), class: "block text-sm font-medium text-gray-700" %>
             </div>
             <div class="w-3/4">
               <%= f.date_field :start_date, required: true,
@@ -39,7 +39,7 @@
 
           <div class="flex items-center">
             <div class="w-1/4">
-              <%= f.label :deadline, "Дедлайн сдачи работ", class: "block text-sm font-medium text-gray-700" %>
+              <%= f.label :deadline, t('.deadline'), class: "block text-sm font-medium text-gray-700" %>
             </div>
             <div class="w-3/4">
               <%= f.date_field :deadline, required: true,
@@ -51,7 +51,7 @@
 
           <div class="flex items-center">
             <div class="w-1/4">
-              <%= f.label :end_date, "Дата окончания джема", class: "block text-sm font-medium text-gray-700" %>
+              <%= f.label :end_date, t('.end_date'), class: "block text-sm font-medium text-gray-700" %>
             </div>
             <div class="w-3/4">
               <%= f.date_field :end_date, required: true,
@@ -67,15 +67,15 @@
                 <%= f.label :status, class: 'block text-sm font-medium text-gray-700' %>
               </div>
               <div class="w-3/4">
-                <p class="text-sm">0 - Модерация; 1 - Одобрено; 2 - Отклонено</p>
+                <p class="text-sm"><%= t('admin.shared.status_hint') %></p>
                 <%= f.select :status, options_for_select([['0', 0], ['1', 1], ['2', 2]], f.object.status),
                              { target: 'status' },
                              class: 'mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50',
                              id: "game_status",
                              data: { action: 'change->status#updateReasonField', status_target: 'status' } %>
                 <div data-status-target="reasonField" style="<%= f.object.status == 2 ? '' : 'display: none;' %>">
-                  <%= f.label :reason, "Причина отклонения", class: 'block text-sm font-medium text-gray-700 mt-2' %>
-                  <%= f.select :reason, [['Непристойный контент', 'Непристойный контент'], ['Реклама', 'Реклама'], ['Плагиат', 'Плагиат']],
+                  <%= f.label :reason, t('admin.shared.rejection_reason'), class: 'block text-sm font-medium text-gray-700 mt-2' %>
+                  <%= f.select :reason, [[t('admin.shared.rejection_reasons.indecent_content'), 'Непристойный контент'], [t('admin.shared.rejection_reasons.advertising'), 'Реклама'], [t('admin.shared.rejection_reasons.plagiarism'), 'Плагиат']],
                                { include_blank: true },
                                class: 'mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50' %>
                 </div>
@@ -85,11 +85,11 @@
 
           <div class="flex items-center">
             <div class="w-1/4">
-              <%= f.label :cover, "Обложка", class: "block text-sm font-medium text-gray-700" %>
+              <%= f.label :cover, t('.cover'), class: "block text-sm font-medium text-gray-700" %>
             </div>
             <div class="w-3/4">
               <label class="block text-sm font-medium text-gray-700 mb-2" for="jam_cover">
-                Обложка
+                <%= t('.cover') %>
               </label>
               <%= f.file_field :cover, class: "mt-1 block w-full text-gray-500 file:py-2 file:px-4 file:border file:border-gray-300 file:rounded-md file:bg-gray-100 file:text-sm file:font-medium hover:file:bg-gray-200 focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50" %>
 
@@ -109,11 +109,11 @@
 
           <div class="flex items-center">
             <div class="w-1/4">
-              <%= f.label :logo, "Логотип", class: "block text-sm font-medium text-gray-700" %>
+              <%= f.label :logo, t('.logo'), class: "block text-sm font-medium text-gray-700" %>
             </div>
             <div class="w-3/4">
               <label class="block text-sm font-medium text-gray-700 mb-2" for="jam_cover">
-                Логотип
+                <%= t('.logo') %>
               </label>
               <%= f.file_field :logo, class: "mt-1 block w-full text-gray-500 file:py-2 file:px-4 file:border file:border-gray-300 file:rounded-md file:bg-gray-100 file:text-sm file:font-medium hover:file:bg-gray-200 focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50" %>
 
@@ -133,7 +133,7 @@
 
           <div class="flex items-center">
             <div class="w-1/4">
-              <%= f.label :tags, "Теги", class: "block text-sm font-medium text-gray-700" %>
+              <%= f.label :tags, t('admin.shared.tags'), class: "block text-sm font-medium text-gray-700" %>
             </div>
             <div class="w-3/4">
               <div class="mt-1">
@@ -151,7 +151,7 @@
             <div class="w-1/4"></div>
             <div class="w-3/4">
               <div class="mt-6 flex items-center space-x-2">
-                <%= f.submit 'Сохранить', class: 'bg-green-500 text-white py-2 px-4 rounded hover:bg-green-600' %>
+                <%= f.submit t('admin.shared.save'), class: 'bg-green-500 text-white py-2 px-4 rounded hover:bg-green-600' %>
               </div>
             </div>
           </div>

--- a/app/views/admin/jams/_jam.html.erb
+++ b/app/views/admin/jams/_jam.html.erb
@@ -8,7 +8,7 @@
           <%= truncate(jam.author.name, length: 15) %>
         </a>
       <% else %>
-        <span>Автор неизвестен</span>
+        <span><%= t('admin.shared.author_unknown') %></span>
       <% end %>
     </td>
     <td class="py-3 px-6 hover:underline">
@@ -17,8 +17,8 @@
     <td class="py-3 px-10"><%= jam.status %></td>
     <td class="py-3 px-6"><%= jam.created_at.strftime("%Y-%m-%d %H:%M") %></td>
     <td class="py-3 px-6 flex flex-col sm:flex-row space-y-2 sm:space-y-0 sm:space-x-2">
-      <%= link_to 'Edit', edit_admin_jam_path(jam), class: 'bg-blue-500 text-white py-1 px-3 rounded hover:bg-blue-600' %>
-      <%= link_to 'Delete', admin_jam_path(jam), class: 'bg-red-500 text-white py-1 px-3 rounded hover:bg-red-600', data: { turbo_method: :delete, turbo_confirm: 'Вы уверены?' } %>
+      <%= link_to t('admin.shared.edit'), edit_admin_jam_path(jam), class: 'bg-blue-500 text-white py-1 px-3 rounded hover:bg-blue-600' %>
+      <%= link_to t('admin.shared.delete'), admin_jam_path(jam), class: 'bg-red-500 text-white py-1 px-3 rounded hover:bg-red-600', data: { turbo_method: :delete, turbo_confirm: t('admin.shared.confirm') } %>
     </td>
   </tr>
 <% end %>

--- a/app/views/admin/jams/index.html.erb
+++ b/app/views/admin/jams/index.html.erb
@@ -3,12 +3,12 @@
     <%= form_with url: admin_jams_path, method: :get, class: "pb-4", local: true do |form| %>
       <div class="flex flex-col md:flex-row items-center space-y-2 md:space-y-0 md:space-x-4 w-full">
         <div class="flex items-center w-full md:w-auto">
-          <%= form.label :query, "Поиск джемов", class: 'block font-semibold text-gray-700 mr-2' %>
+          <%= form.label :query, t('.search_label'), class: 'block font-semibold text-gray-700 mr-2' %>
           <%= form.text_field :query, value: params[:query], placeholder: '', class: 'border border-gray-300 rounded-lg p-2 text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent w-full' %>
         </div>
         <div class="flex items-center space-x-2 mt-2 md:mt-0">
-          <%= form.submit 'Поиск', class: 'bg-blue-500 text-white font-semibold py-2 px-4 rounded-lg hover:bg-blue-600 transition duration-150 ease-in-out shadow' %>
-          <%= link_to 'Сбросить', admin_jams_path, class: 'text-gray-500 hover:text-gray-700 font-semibold' %>
+          <%= form.submit t('admin.shared.search'), class: 'bg-blue-500 text-white font-semibold py-2 px-4 rounded-lg hover:bg-blue-600 transition duration-150 ease-in-out shadow' %>
+          <%= link_to t('admin.shared.reset'), admin_jams_path, class: 'text-gray-500 hover:text-gray-700 font-semibold' %>
         </div>
       </div>
     <% end %>
@@ -49,6 +49,6 @@
     </div>
     <%= render partial: 'helpers/pagy' %>
   <% else %>
-    <p class="text-gray-500 m-8">Джемы не найдены по запросу "<%= params[:query] %>".</p>
+    <p class="text-gray-500 m-8"><%= t('.not_found', query: params[:query]) %></p>
   <% end %>
 </div>

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -1,15 +1,15 @@
 <div class="p-6" data-controller="settings">
   <div class="flex flex-col md:flex-row space-y-2 md:space-y-0 md:space-x-4 mb-4">
-    <button data-target="settings.button" data-action="click->settings#showSection" data-section="profile" class="button bg-blue-700 text-white py-2 px-4 rounded">Профиль</button>
-    <button data-target="settings.button" data-action="click->settings#showSection" data-section="user_experience" class="button bg-blue-500 text-white py-2 px-4 rounded">Пользовательский опыт</button>
-    <button data-target="settings.button" data-action="click->settings#showSection" data-section="games" class="button bg-blue-500 text-white py-2 px-4 rounded">Игры</button>
-    <button data-target="settings.button" data-action="click->settings#showSection" data-section="jams" class="button bg-blue-500 text-white py-2 px-4 rounded">Джемы</button>
-    <button data-target="settings.button" data-action="click->settings#showSection" data-section="sessions" class="button bg-blue-500 text-white py-2 px-4 rounded">Сессии</button>
-    <button data-target="settings.button" data-action="click->settings#showSection" data-section="notifications" class="button bg-blue-500 text-white py-2 px-4 rounded">Уведомления</button>
+    <button data-target="settings.button" data-action="click->settings#showSection" data-section="profile" class="button bg-blue-700 text-white py-2 px-4 rounded"><%= t('.tabs.profile') %></button>
+    <button data-target="settings.button" data-action="click->settings#showSection" data-section="user_experience" class="button bg-blue-500 text-white py-2 px-4 rounded"><%= t('.tabs.user_experience') %></button>
+    <button data-target="settings.button" data-action="click->settings#showSection" data-section="games" class="button bg-blue-500 text-white py-2 px-4 rounded"><%= t('.tabs.games') %></button>
+    <button data-target="settings.button" data-action="click->settings#showSection" data-section="jams" class="button bg-blue-500 text-white py-2 px-4 rounded"><%= t('.tabs.jams') %></button>
+    <button data-target="settings.button" data-action="click->settings#showSection" data-section="sessions" class="button bg-blue-500 text-white py-2 px-4 rounded"><%= t('.tabs.sessions') %></button>
+    <button data-target="settings.button" data-action="click->settings#showSection" data-section="notifications" class="button bg-blue-500 text-white py-2 px-4 rounded"><%= t('.tabs.notifications') %></button>
   </div>
 
   <div class="mt-4">
-    <%= link_to 'Назад', request.referer && URI(request.referer).path != request.fullpath ? URI(request.referer).path : admin_users_path, class: 'bg-gray-300 text-gray-800 py-2 px-4 rounded hover:bg-gray-400' %>
+    <%= link_to t('admin.shared.back'), request.referer && URI(request.referer).path != request.fullpath ? URI(request.referer).path : admin_users_path, class: 'bg-gray-300 text-gray-800 py-2 px-4 rounded hover:bg-gray-400' %>
   </div>
 
   <div>
@@ -63,7 +63,7 @@
           <div id="hidden-section" class="space-y-4 mt-4 hidden">
             <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
               <div>
-                <label for="avatar" class="block text-sm font-medium text-gray-800">Аватар</label>
+                <label for="avatar" class="block text-sm font-medium text-gray-800"><%= t('.avatar') %></label>
                 <div class="flex items-center gap-x-4 bg-white p-4 rounded-md border border-gray-300 shadow-sm">
                   <% if user && user.avatar.attached? %>
                     <%= image_tag url_for(user.avatar), alt: "Profile Picture", class: "avatar-image rounded-full h-24 w-24 object-cover" %>
@@ -78,7 +78,7 @@
               </div>
 
               <div>
-                <label for="background_image" class="block text-sm font-medium text-gray-800">Заставка</label>
+                <label for="background_image" class="block text-sm font-medium text-gray-800"><%= t('.background_image') %></label>
                 <div data-controller="background-image">
                   <div class="relative">
                     <div class="max-w-full border-dashed border-2 border-gray-400 p-4 text-center rounded-md bg-white shadow-md">
@@ -88,12 +88,12 @@
                              alt="Current Background Image" class="max-h-56 mb-4 object-cover rounded-md shadow-sm" />
                       <% end %>
                       <img data-background-image-target="previewImg" id="preview-img" src="#"
-                           alt="Предварительный просмотр изображения"
+                           alt="<%= t('.background_preview_alt') %>"
                            class="mt-4 hidden w-full h-auto object-cover rounded-md shadow-sm">
                       <input data-background-image-target="input" type="file" name="user[background_image]"
                              id="background_image"
                              class="absolute inset-0 opacity-0 cursor-pointer max-h-56" accept="image/*">
-                      <label for="background_image" class="mt-2 text-xs text-gray-500 cursor-pointer hover:text-gray-700">Загрузить новую заставку</label>
+                      <label for="background_image" class="mt-2 text-xs text-gray-500 cursor-pointer hover:text-gray-700"><%= t('.upload_new_background') %></label>
                     </div>
                   </div>
                 </div>
@@ -118,7 +118,7 @@
 
               <div>
                 <label for="link_username" class="block text-sm font-medium text-gray-700">
-                  Персональная ссылка
+                  <%= t('.personal_link') %>
                 </label>
                 <%= f.text_field :link_username, id: 'link_username',
                                  class: 'mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50', placeholder: 'Username',
@@ -138,7 +138,7 @@
 
             <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
               <div>
-                <label for="phone_number" class="block text-sm font-medium text-gray-700">Номер телефона</label>
+                <label for="phone_number" class="block text-sm font-medium text-gray-700"><%= t('.phone_number') %></label>
                 <%= f.text_field :phone_number, id: 'phone_number',
                                  value: user.phone_number,
                                  autocomplete: 'tel',
@@ -148,7 +148,7 @@
               </div>
 
               <div>
-                <label for="birthday" class="block text-sm font-medium text-gray-700">День рождения</label>
+                <label for="birthday" class="block text-sm font-medium text-gray-700"><%= t('.birthday') %></label>
                 <%= f.text_field :birthday, id: 'birthday',
                                  value: user.birthday,
                                  autocomplete: 'birthday',
@@ -246,57 +246,64 @@
             </div>
           </div>
 
-          <div data-controller="freeze" data-user-id="<%= user.id %>">
+          <div data-controller="freeze"
+               data-user-id="<%= user.id %>"
+               data-freeze-reason-required-value="<%= t('.freeze.reason_required') %>"
+               data-freeze-freezing-value="<%= t('.freeze.freezing') %>"
+               data-freeze-error-value="<%= t('.freeze.error') %>"
+               data-freeze-freeze-label-value="<%= t('.freeze.freeze') %>">
             <div class="flex items-center justify-end pb-10 space-x-2">
-              <%= f.submit 'Сохранить', class: 'bg-green-500 text-white py-2 px-4 rounded hover:bg-green-600' %>
+              <%= f.submit t('admin.shared.save'), class: 'bg-green-500 text-white py-2 px-4 rounded hover:bg-green-600' %>
               <button type="button" class="bg-red-500 text-white py-2 px-4 rounded hover:bg-red-600" data-action="click->freeze#open">
-                Заморозить
+                <%= t('.freeze.freeze') %>
               </button>
-              <div data-controller="unfreeze" data-user-id="<%= user.id %>">
+              <div data-controller="unfreeze"
+                   data-user-id="<%= user.id %>"
+                   data-unfreeze-error-value="<%= t('.freeze.unfreeze_error') %>">
                 <button type="button"
                         class="bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600"
                         data-action="click->unfreeze#unfreezeUser">
-                  Разморозить
+                  <%= t('.freeze.unfreeze') %>
                 </button>
               </div>
             </div>
 
             <div id="freeze-modal" class="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 hidden">
               <div class="bg-white p-6 rounded-lg w-96">
-                <h2 class="text-lg font-semibold mb-4">Заморозка пользователя</h2>
+                <h2 class="text-lg font-semibold mb-4"><%= t('.freeze.modal_title') %></h2>
 
-                <label for="freeze-reason" class="block text-sm font-medium text-gray-700">Причина:</label>
+                <label for="freeze-reason" class="block text-sm font-medium text-gray-700"><%= t('.freeze.reason') %></label>
                 <textarea id="freeze-reason"
                           class="w-full border rounded p-2 mb-4 resize-none"
                           rows="3"
                           data-freeze-target="reason"
                           data-action="input->freeze#checkInput"
-                          placeholder="Введите причину заморозки"></textarea>
+                          placeholder="<%= t('.freeze.reason_placeholder') %>"></textarea>
 
-                <label for="freeze-duration" class="block text-sm font-medium text-gray-700">На сколько:</label>
+                <label for="freeze-duration" class="block text-sm font-medium text-gray-700"><%= t('.freeze.duration') %></label>
                 <select id="freeze-duration" class="w-full border rounded p-2 mb-4" data-freeze-target="duration">
-                  <option value="1.hour">1 час</option>
-                  <option value="6.hours">6 часов</option>
-                  <option value="12.hours">12 часов</option>
-                  <option value="1.day">1 сутки</option>
-                  <option value="3.days">3 суток</option>
-                  <option value="7.days">7 суток</option>
-                  <option value="1.month">1 месяц</option>
-                  <option value="6.months">6 месяцев</option>
-                  <option value="1.year">1 год</option>
-                  <option value="forever">Бессрочно</option>
+                  <option value="1.hour"><%= t('.freeze.durations.hour_1') %></option>
+                  <option value="6.hours"><%= t('.freeze.durations.hours_6') %></option>
+                  <option value="12.hours"><%= t('.freeze.durations.hours_12') %></option>
+                  <option value="1.day"><%= t('.freeze.durations.day_1') %></option>
+                  <option value="3.days"><%= t('.freeze.durations.days_3') %></option>
+                  <option value="7.days"><%= t('.freeze.durations.days_7') %></option>
+                  <option value="1.month"><%= t('.freeze.durations.month_1') %></option>
+                  <option value="6.months"><%= t('.freeze.durations.months_6') %></option>
+                  <option value="1.year"><%= t('.freeze.durations.year_1') %></option>
+                  <option value="forever"><%= t('.freeze.durations.forever') %></option>
                 </select>
 
                 <div class="flex justify-end space-x-2">
                   <button class="bg-gray-300 text-black py-2 px-4 rounded hover:bg-gray-400"
                           data-action="click->freeze#close">
-                    Отмена
+                    <%= t('.freeze.cancel') %>
                   </button>
                   <button class="bg-red-500 text-white py-2 px-4 rounded hover:bg-red-600 opacity-50 cursor-not-allowed"
                           data-freeze-target="submit"
                           data-action="click->freeze#submit"
                           disabled>
-                    Заморозить
+                    <%= t('.freeze.freeze') %>
                   </button>
                 </div>
               </div>
@@ -307,11 +314,11 @@
 
       <% if @user.is_frozen? %>
         <div class="alert alert-danger text-red-500">
-          <strong>Пользователь заморожен!</strong>
+          <strong><%= t('.frozen.title') %></strong>
           <br>
-          <span>Причина: <%= @user.frozen_reason %></span>
+          <span><%= t('.frozen.reason') %> <%= @user.frozen_reason %></span>
           <br>
-          <span>Дата разморозки: <%= @user.unfreeze_at.present? ? @user.unfreeze_at.strftime("%d-%m-%Y %H:%M") : "Бессрочно" %></span>
+          <span><%= t('.frozen.unfreeze_at') %> <%= @user.unfreeze_at.present? ? @user.unfreeze_at.strftime("%d-%m-%Y %H:%M") : t('.freeze.durations.forever') %></span>
         </div>
       <% end %>
     </div>
@@ -320,7 +327,7 @@
     <div data-settings-target="section" data-section="user_experience" class="hidden">
       <div class="container mx-auto px-4 pt-4">
         <div class="section pb-16">
-          <h2 class="text-2xl font-bold tracking-tight text-gray-900">Друзья</h2>
+          <h2 class="text-2xl font-bold tracking-tight text-gray-900"><%= t('.friends.title') %></h2>
           <div class="friend-list grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             <% if @user_friendships.count > 0 %>
               <% @user_friendships.each do |user_friendship| %>
@@ -360,14 +367,14 @@
                 <% end %>
               <% end %>
             <% else %>
-              <p class="text-xl font-bold tracking-tight text-gray-600">Друзей пока нет</p>
+              <p class="text-xl font-bold tracking-tight text-gray-600"><%= t('.friends.empty') %></p>
             <% end %>
           </div>
         </div>
 
         <!-- Заявки -->
         <div class="section pb-16">
-          <h2 class="text-2xl font-bold tracking-tight text-gray-900">Заявки</h2>
+          <h2 class="text-2xl font-bold tracking-tight text-gray-900"><%= t('.requests.title') %></h2>
           <div class="request-list grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             <% if @user_sent_requests.count > 0 %>
               <% @user_sent_requests.each do |user_request| %>
@@ -407,14 +414,14 @@
                 <% end %>
               <% end %>
             <% else %>
-              <p class="text-xl font-bold tracking-tight text-gray-600">Исходящие запросы пока пусты</p>
+              <p class="text-xl font-bold tracking-tight text-gray-600"><%= t('.requests.empty_outgoing') %></p>
             <% end %>
           </div>
         </div>
 
         <!-- Подписчики -->
         <div class="section pb-16">
-          <h2 class="text-2xl font-bold tracking-tight text-gray-900">Подписчики</h2>
+          <h2 class="text-2xl font-bold tracking-tight text-gray-900"><%= t('.subscribers.title') %></h2>
           <div class="followers-list grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             <% if @user_received_requests.count > 0 %>
               <% @user_received_requests.each do |user_request| %>
@@ -454,7 +461,7 @@
                 <% end %>
               <% end %>
             <% else %>
-              <p class="text-xl font-bold tracking-tight text-gray-600">Входящие запросы пока пусты</p>
+              <p class="text-xl font-bold tracking-tight text-gray-600"><%= t('.subscribers.empty_incoming') %></p>
             <% end %>
           </div>
         </div>
@@ -466,7 +473,7 @@
       <div class="space-y-4 p-4 md:p-16">
         <div class="flex flex-col md:flex-row items-start">
           <div class="w-full md:w-1/4 mb-4 md:mb-0">
-            <p class="block text-sm font-medium text-gray-700">Игры</p>
+            <p class="block text-sm font-medium text-gray-700"><%= t('.games_section.title') %></p>
           </div>
           <div class="w-full md:w-3/4">
             <% if @user.games.any? %>
@@ -495,17 +502,17 @@
                     </a>
 
                     <div class="pt-2">
-                      <%= link_to 'Edit', edit_admin_game_path(game),
+                      <%= link_to t('admin.shared.edit'), edit_admin_game_path(game),
                                   class: 'bg-blue-500 text-white py-1 px-3 rounded hover:bg-blue-600' %>
-                      <%= link_to 'Delete', admin_game_path(game),
+                      <%= link_to t('admin.shared.delete'), admin_game_path(game),
                                   class: 'bg-red-500 text-white py-1 px-3 rounded hover:bg-red-600',
-                                  data: { turbo_method: :delete, turbo_confirm: 'Вы уверены?' } %>
+                                  data: { turbo_method: :delete, turbo_confirm: t('admin.shared.confirm') } %>
                     </div>
                   </li>
                 <% end %>
               </ul>
             <% else %>
-              <span class="text-sm text-gray-500">Информации нет</span>
+              <span class="text-sm text-gray-500"><%= t('.no_info') %></span>
             <% end %>
           </div>
         </div>
@@ -517,7 +524,7 @@
       <div class="space-y-4 p-4 md:p-16">
         <div class="flex flex-col md:flex-row items-start">
           <div class="w-full md:w-1/4 mb-4 md:mb-0">
-            <p class="block text-sm font-medium text-gray-700">Джемы</p>
+            <p class="block text-sm font-medium text-gray-700"><%= t('.jams_section.title') %></p>
           </div>
           <div class="w-full md:w-3/4">
             <% if @user.jams.any? %>
@@ -546,17 +553,17 @@
                     </a>
 
                     <div class="pt-2">
-                      <%= link_to 'Edit', edit_admin_jam_path(jam),
+                      <%= link_to t('admin.shared.edit'), edit_admin_jam_path(jam),
                                   class: 'bg-blue-500 text-white py-1 px-3 rounded hover:bg-blue-600' %>
-                      <%= link_to 'Delete', admin_jam_path(jam),
+                      <%= link_to t('admin.shared.delete'), admin_jam_path(jam),
                                   class: 'bg-red-500 text-white py-1 px-3 rounded hover:bg-red-600',
-                                  data: { turbo_method: :delete, turbo_confirm: 'Вы уверены?' } %>
+                                  data: { turbo_method: :delete, turbo_confirm: t('admin.shared.confirm') } %>
                     </div>
                   </li>
                 <% end %>
               </ul>
             <% else %>
-              <span class="text-sm text-gray-500">Информации нет</span>
+              <span class="text-sm text-gray-500"><%= t('.no_info') %></span>
             <% end %>
           </div>
         </div>
@@ -568,7 +575,7 @@
       <div class="space-y-4 p-4 md:p-16">
         <div class="flex flex-col md:flex-row items-start">
           <div class="w-full md:w-1/4 mb-4 md:mb-0">
-            <p class="block text-sm font-medium text-gray-700">Активные сессии</p>
+            <p class="block text-sm font-medium text-gray-700"><%= t('.sessions_section.title') %></p>
           </div>
           <div class="w-full md:w-3/4">
             <% if @user_sessions.any? %>
@@ -591,7 +598,7 @@
                 <%= submit_tag 'Log out all', class: 'mt-4 bg-red-500 text-white py-1 px-3 rounded hover:bg-red-600' %>
               <% end %>
             <% else %>
-              <p class="text-sm text-gray-500">Не найдено активных сессий</p>
+              <p class="text-sm text-gray-500"><%= t('.sessions_section.empty') %></p>
             <% end %>
           </div>
         </div>
@@ -603,7 +610,7 @@
       <div class="space-y-4 p-4 md:p-16">
         <div class="flex flex-col md:flex-row items-start">
           <div class="w-full md:w-1/4 mb-4 md:mb-0">
-            <p class="block text-sm font-medium text-gray-700">Уведомления</p>
+            <p class="block text-sm font-medium text-gray-700"><%= t('.notifications_section.title') %></p>
           </div>
           <div class="w-full md:w-3/4">
             <% if @user_notifications.any? %>
@@ -627,9 +634,9 @@
                           <%= notification.actor.name %>
                         </a>
                         <% if notification.action == 'accepted_friendship' %>
-                          принял заявку в друзья
+                          <%= t('.notifications_section.accepted_friendship') %>
                         <% elsif notification.action == 'sent_friend_request' %>
-                          отправил запрос в друзья
+                          <%= t('.notifications_section.sent_friend_request') %>
                         <% else %>
                           <%= notification.action %>
                         <% end %>
@@ -640,7 +647,7 @@
                 <% end %>
               <% end %>
             <% else %>
-              <p class="text-sm text-gray-500">У пользователя не было ни одного уведомления</p>
+              <p class="text-sm text-gray-500"><%= t('.notifications_section.empty') %></p>
             <% end %>
           </div>
         </div>

--- a/app/views/admin/users/_user.html.erb
+++ b/app/views/admin/users/_user.html.erb
@@ -9,9 +9,9 @@
     <td class="py-3 px-6"><%= user.role %></td>
     <td class="py-3 px-6"><%= user.created_at %></td>
     <td class="py-3 px-6 flex flex-col sm:flex-row space-y-2 sm:space-y-0 sm:space-x-2">
-      <%= link_to 'Edit', edit_admin_user_path(user), class: 'bg-blue-500 text-white py-1 px-3 rounded hover:bg-blue-600' %>
-      <%= link_to 'Delete', admin_user_path(user), class: 'bg-red-500 text-white py-1 px-3 rounded hover:bg-red-600',
-                  data: { turbo_method: :delete, turbo_confirm: 'Вы уверены?' } %>
+      <%= link_to t('admin.shared.edit'), edit_admin_user_path(user), class: 'bg-blue-500 text-white py-1 px-3 rounded hover:bg-blue-600' %>
+      <%= link_to t('admin.shared.delete'), admin_user_path(user), class: 'bg-red-500 text-white py-1 px-3 rounded hover:bg-red-600',
+                  data: { turbo_method: :delete, turbo_confirm: t('admin.shared.confirm') } %>
     </td>
   </tr>
 <% end %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -3,17 +3,17 @@
     <%= form_with url: admin_users_path, method: :get, class: "pb-4", local: true do |form| %>
       <div class="flex flex-col md:flex-row items-center space-y-2 md:space-y-0 md:space-x-4 w-full">
         <div class="flex items-center w-full md:w-auto">
-          <%= form.label :query, "Поиск пользователей", class: 'block font-semibold text-gray-700 mr-2' %>
+          <%= form.label :query, t('.search_label'), class: 'block font-semibold text-gray-700 mr-2' %>
           <%= form.text_field :query, value: params[:query], placeholder: '', class: 'border border-gray-300 rounded-lg p-2 text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent w-full' %>
         </div>
         <div class="flex items-center space-x-2 mt-2 md:mt-0">
-          <%= form.submit 'Поиск', class: 'bg-blue-500 text-white font-semibold py-2 px-4 rounded-lg hover:bg-blue-600 transition duration-150 ease-in-out shadow' %>
-          <%= link_to 'Сбросить', admin_users_path, class: 'text-gray-500 hover:text-gray-700 font-semibold' %>
+          <%= form.submit t('admin.shared.search'), class: 'bg-blue-500 text-white font-semibold py-2 px-4 rounded-lg hover:bg-blue-600 transition duration-150 ease-in-out shadow' %>
+          <%= link_to t('admin.shared.reset'), admin_users_path, class: 'text-gray-500 hover:text-gray-700 font-semibold' %>
         </div>
       </div>
     <% end %>
     <div class="mt-4 md:mt-0 md:flex-shrink-0 md:ml-0">
-      <%= link_to 'Создать пользователя', new_admin_user_path, class: 'bg-green-500 text-white py-2 px-4 rounded hover:bg-green-600 transition duration-150 ease-in-out' %>
+      <%= link_to t('.create_user'), new_admin_user_path, class: 'bg-green-500 text-white py-2 px-4 rounded hover:bg-green-600 transition duration-150 ease-in-out' %>
     </div>
   </div>
 
@@ -52,6 +52,6 @@
     </div>
     <%= render partial: 'helpers/pagy' %>
   <% else %>
-    <p class="text-gray-500 m-8">Пользователи не найдены по запросу "<%= params[:query] %>".</p>
+    <p class="text-gray-500 m-8"><%= t('.not_found', query: params[:query]) %></p>
   <% end %>
 </div>

--- a/app/views/admin/users/new.html.erb
+++ b/app/views/admin/users/new.html.erb
@@ -1,25 +1,25 @@
 <div class="p-16">
-  <h1 class="text-xl font-bold mb-4">Создание нового пользователя</h1>
+  <h1 class="text-xl font-bold mb-4"><%= t('.title') %></h1>
 
   <%= form_with model: @user, url: admin_users_path, method: :post, local: true, class: 'mb-4' do |form| %>
-    <%= form.label :name, 'Имя', class: 'block mb-1' %>
+    <%= form.label :name, t('.name'), class: 'block mb-1' %>
     <%= form.text_field :name, class: 'border p-2 mb-4 w-full' %>
 
-    <%= form.label :email, 'Email', class: 'block mb-1' %>
+    <%= form.label :email, t('.email'), class: 'block mb-1' %>
     <%= form.email_field :email, class: 'border p-2 mb-4 w-full' %>
 
-    <%= form.label :password, 'Пароль', class: 'block mb-1' %>
+    <%= form.label :password, t('.password'), class: 'block mb-1' %>
     <%= form.password_field :password, class: 'border p-2 mb-4 w-full' %>
 
-    <%= form.label :password_confirmation, 'Подтверждение пароля', class: 'block mb-1' %>
+    <%= form.label :password_confirmation, t('.password_confirmation'), class: 'block mb-1' %>
     <%= form.password_field :password_confirmation, class: 'border p-2 mb-4 w-full' %>
 
-    <%= form.label :role, 'Роль', class: 'block mb-1' %>
+    <%= form.label :role, t('.role'), class: 'block mb-1' %>
     <%= form.select :role, User.roles.keys.map { |role| [role.humanize, role] }, class: 'border p-2 mb-4 w-full' %>
 
     <div class="mt-6 flex items-center space-x-2">
-      <%= form.submit 'Создать пользователя', class: 'bg-green-500 text-white py-2 px-4 rounded hover:bg-green-600' %>
-      <%= link_to 'Назад', request.referer && URI(request.referer).path != request.fullpath ? URI(request.referer).path : admin_users_path, class: 'bg-gray-300 text-gray-800 py-2 px-4 rounded hover:bg-gray-400' %>
+      <%= form.submit t('.submit'), class: 'bg-green-500 text-white py-2 px-4 rounded hover:bg-green-600' %>
+      <%= link_to t('admin.shared.back'), request.referer && URI(request.referer).path != request.fullpath ? URI(request.referer).path : admin_users_path, class: 'bg-gray-300 text-gray-800 py-2 px-4 rounded hover:bg-gray-400' %>
     </div>
   <% end %>
 </div>

--- a/app/views/admin/visits/index.html.erb
+++ b/app/views/admin/visits/index.html.erb
@@ -1,9 +1,14 @@
-<div data-controller="visits" class="max-w-6xl mx-auto p-6 bg-white rounded-lg shadow-lg">
-  <h1 class="text-2xl font-bold text-center mb-4 text-gray-800">График активности пользователей</h1>
+<div data-controller="visits"
+     data-visits-active-users-label-value="<%= t('.active_users') %>"
+     data-visits-registered-users-label-value="<%= t('.registered_users') %>"
+     data-visits-user-count-label-value="<%= t('.user_count') %>"
+     data-visits-date-label-value="<%= t('.date') %>"
+     class="max-w-6xl mx-auto p-6 bg-white rounded-lg shadow-lg">
+  <h1 class="text-2xl font-bold text-center mb-4 text-gray-800"><%= t('.title') %></h1>
 
   <select id="time-frame" data-action="change->visits#changeTimeFrame" class="mb-4">
-    <option value="30">За крайние 30 дней</option>
-    <option value="90">За крайние 90 дней</option>
+    <option value="30"><%= t('.last_30_days') %></option>
+    <option value="90"><%= t('.last_90_days') %></option>
   </select>
 
   <canvas data-visits-target="chart" class="w-full h-64 border border-gray-200 rounded-lg shadow-sm"></canvas>

--- a/app/views/admins/index.html.erb
+++ b/app/views/admins/index.html.erb
@@ -1,61 +1,61 @@
 <div class="p-16">
-  <h1 class="text-3xl font-bold mb-6">Панель администратора</h1>
+  <h1 class="text-3xl font-bold mb-6"><%= t('.title') %></h1>
 
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
     <div class="bg-white shadow-md rounded-lg p-6 flex flex-col justify-between h-full">
       <div>
-        <h2 class="text-xl font-semibold mb-2">Пользователи</h2>
-        <p class="text-gray-600 mb-4">Управление пользователями</p>
+        <h2 class="text-xl font-semibold mb-2"><%= t('.users.title') %></h2>
+        <p class="text-gray-600 mb-4"><%= t('.users.description') %></p>
       </div>
-      <%= link_to 'Перейти', admin_users_path, class: 'bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600 transition mt-4' %>
+      <%= link_to t('.go'), admin_users_path, class: 'bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600 transition mt-4' %>
     </div>
 
     <div class="bg-white shadow-md rounded-lg p-6 flex flex-col justify-between h-full">
       <div>
-        <h2 class="text-xl font-semibold mb-2">Игры</h2>
-        <p class="text-gray-600 mb-4">Редактирование и удаление игр</p>
+        <h2 class="text-xl font-semibold mb-2"><%= t('.games.title') %></h2>
+        <p class="text-gray-600 mb-4"><%= t('.games.description') %></p>
       </div>
-      <%= link_to 'Перейти', admin_games_path, class: 'bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600 transition mt-4' %>
+      <%= link_to t('.go'), admin_games_path, class: 'bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600 transition mt-4' %>
     </div>
 
     <div class="bg-white shadow-md rounded-lg p-6 flex flex-col justify-between h-full">
       <div>
-        <h2 class="text-xl font-semibold mb-2">Джемы</h2>
-        <p class="text-gray-600 mb-4">Управление джемами и их участниками</p>
+        <h2 class="text-xl font-semibold mb-2"><%= t('.jams.title') %></h2>
+        <p class="text-gray-600 mb-4"><%= t('.jams.description') %></p>
       </div>
-      <%= link_to 'Перейти', admin_jams_path, class: 'bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600 transition mt-4' %>
+      <%= link_to t('.go'), admin_jams_path, class: 'bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600 transition mt-4' %>
     </div>
 
     <div class="bg-white shadow-md rounded-lg p-6 flex flex-col justify-between h-full">
       <div>
-        <h2 class="text-xl font-semibold mb-2">Статистика</h2>
-        <p class="text-gray-600 mb-4">Просмотр статистики пользователей, игр и джемов</p>
+        <h2 class="text-xl font-semibold mb-2"><%= t('.stats.title') %></h2>
+        <p class="text-gray-600 mb-4"><%= t('.stats.description') %></p>
       </div>
-      <%= link_to 'Перейти', admin_visits_path, class: 'bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600 transition mt-4' %>
+      <%= link_to t('.go'), admin_visits_path, class: 'bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600 transition mt-4' %>
     </div>
 
     <div class="bg-white shadow-md rounded-lg p-6 flex flex-col justify-between h-full">
       <div>
-        <h2 class="text-xl font-semibold mb-2">Настройки</h2>
-        <p class="text-gray-600 mb-4">Настройка параметров платформы</p>
+        <h2 class="text-xl font-semibold mb-2"><%= t('.settings.title') %></h2>
+        <p class="text-gray-600 mb-4"><%= t('.settings.description') %></p>
       </div>
-      <%= link_to 'Перейти', '', class: 'bg-gray-500 text-white px-4 py-2 rounded hover:bg-gray-600 transition mt-4' %>
+      <%= link_to t('.go'), '', class: 'bg-gray-500 text-white px-4 py-2 rounded hover:bg-gray-600 transition mt-4' %>
     </div>
 
     <div class="bg-white shadow-md rounded-lg p-6 flex flex-col justify-between h-full">
       <div>
-        <h2 class="text-xl font-semibold mb-2">Поддержка</h2>
-        <p class="text-gray-600 mb-4">Связь с поддержкой, часто задаваемые вопросы</p>
+        <h2 class="text-xl font-semibold mb-2"><%= t('.support.title') %></h2>
+        <p class="text-gray-600 mb-4"><%= t('.support.description') %></p>
       </div>
-      <%= link_to 'Перейти', '', class: 'bg-gray-500 text-white px-4 py-2 rounded hover:bg-gray-600 transition mt-4' %>
+      <%= link_to t('.go'), '', class: 'bg-gray-500 text-white px-4 py-2 rounded hover:bg-gray-600 transition mt-4' %>
     </div>
 
     <div class="bg-white shadow-md rounded-lg p-6 flex flex-col justify-between h-full">
       <div>
-        <h2 class="text-xl font-semibold mb-2">Действия администраторов</h2>
-        <p class="text-gray-600 mb-4">Просмотр всех действий, совершенных администраторами</p>
+        <h2 class="text-xl font-semibold mb-2"><%= t('.actions.title') %></h2>
+        <p class="text-gray-600 mb-4"><%= t('.actions.description') %></p>
       </div>
-      <%= link_to 'Перейти', admin_actions_path, class: 'bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600 transition mt-4' %>
+      <%= link_to t('.go'), admin_actions_path, class: 'bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600 transition mt-4' %>
     </div>
   </div>
 </div>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -165,13 +165,13 @@
 
     <div class="mt-8">
       <h3 class="text-2xl font-bold tracking-tight text-gray-900">
-        Мои джемы
+        <%= t '.my_jams' %>
       </h3>
       <div class="mt-4">
         <% if @user_jams.any? %>
           <%= render partial: 'jams/showcase_grid', locals: { jams: @user_jams } %>
         <% else %>
-          <p class="text-sm text-gray-500">Вы пока не участвуете и не администрируете ни в одном джеме.</p>
+          <p class="text-sm text-gray-500"><%= t '.no_jams' %></p>
         <% end %>
       </div>
     </div>

--- a/app/views/email_confirm_mailer/email_confirm.html.erb
+++ b/app/views/email_confirm_mailer/email_confirm.html.erb
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="ru">
+<html lang="<%= I18n.locale %>">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Подтверждение электронной почты</title>
+  <title><%= t('mailers.email_confirm.title') %></title>
   <style>
       body {
           font-family: Arial, sans-serif;
@@ -41,8 +41,8 @@
 <body>
 
 <div class="container">
-  <h1>Подтверждение электронной почты</h1>
-  <p>Вам необходимо подтвердить адрес электронной почты для регистрации на Jammer. Пожалуйста, скопируйте этот код для подтверждения:</p>
+  <h1><%= t('mailers.email_confirm.title') %></h1>
+  <p><%= t('mailers.email_confirm.body') %></p>
   <p class="code">
     <% if @user && @token && @user.email_confirm_token %>
       <%= @token %>

--- a/app/views/email_confirm_mailer/email_confirm.text.erb
+++ b/app/views/email_confirm_mailer/email_confirm.text.erb
@@ -1,5 +1,5 @@
-Подтверждение электронной почты
-Вам необходимо подтвердить адрес электронной почты для регистрации на Jammer. Пожалуйста, скопируйте этот код для подтверждения:
+<%= t('mailers.email_confirm.title') %>
+<%= t('mailers.email_confirm.body') %>
 <% if @user && @token && @user.email_confirm_token %>
     <%= @token %>
 <% end %>

--- a/app/views/email_confirms/edit.html.erb
+++ b/app/views/email_confirms/edit.html.erb
@@ -17,7 +17,7 @@
       </div>
 
       <div class="mt-4 text-center">
-        <p class="text-red-600">Внимание: Почту необходимо подтвердить в течение часа после регистрации, иначе ваш аккаунт будет удален</p>
+        <p class="text-red-600"><%= t '.warning' %></p>
       </div>
 
       <div class="mt-4 text-center">

--- a/app/views/games/_form.html.erb
+++ b/app/views/games/_form.html.erb
@@ -28,11 +28,11 @@
         <div class="text-gray-500 border-dashed border-2 border-gray-400 p-6 text-center rounded-md relative">
           <% if @game.persisted? && @game.cover.attached? %>
             <img data-games-target="coverPreviewImg" src="<%= url_for(@game.cover) %>"
-                 alt="Предварительный просмотр обложки"
+                 alt="<%= t('.cover_preview_alt') %>"
                  class="mt-4 w-full h-auto object-cover rounded-md">
           <% else %>
             <img data-games-target="coverPreviewImg" src="#"
-                 alt="Предварительный просмотр обложки"
+                 alt="<%= t('.cover_preview_alt') %>"
                  class="mt-4 hidden w-full h-auto object-cover rounded-md">
           <% end %>
 
@@ -101,7 +101,7 @@
     <%= submit_tag (@game.persisted? ? t('games.show.edit') : t('.btn')), class: "mt-4 flex w-full justify-center rounded-md border
        border-transparent bg-indigo-600 py-2 px-4 text-sm font-medium text-white shadow-sm
         hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2",
-                   data: { turbo_submits_with: "Создаем...", turbo_track: "dynamic" } %>
+                   data: { turbo_submits_with: t('.submitting'), turbo_track: "dynamic" } %>
 
     <div class='blur-background hidden' id='blur'>
       <div class="loading-spinner hidden" id="loading">

--- a/app/views/games/_showcase.html.erb
+++ b/app/views/games/_showcase.html.erb
@@ -1,8 +1,8 @@
 <div class="bg-white">
   <div class="mx-auto max-w-2xl px-4 py-16 sm:px-6 lg:max-w-7xl lg:px-8">
     <div class="flex justify-between items-center">
-      <h2 class="text-2xl font-bold tracking-tight text-gray-900">Каталог игр</h2>
-      <%= button_to "Создать игру", games_new_path, method: :get,
+      <h2 class="text-2xl font-bold tracking-tight text-gray-900"><%= t('games.showcase.title') %></h2>
+      <%= button_to t('games.showcase.create'), games_new_path, method: :get,
                     class: "rounded-md border border-transparent bg-indigo-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2" %>
     </div>
     <div class="mt-6 grid grid-cols-1 gap-x-6 gap-y-10 sm:grid-cols-2 lg:grid-cols-4 xl:gap-x-8">

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -7,8 +7,8 @@
             <h1 class="text-2xl font-medium text-gray-900 break-all"><%= @game.name %></h1>
           </div>
           <% if @game.status != 1 %>
-            <p class="mt-2 text-red-400 sm:text-sm">Данная игра
-              <%= @game.status == 0 ? 'находится на модерации' : 'отклонена модератором' %>
+            <p class="mt-2 text-red-400 sm:text-sm"><%= t('.this_game') %>
+              <%= @game.status == 0 ? t('.status_pending') : t('.status_rejected') %>
             </p>
           <% end %>
         </div>
@@ -45,12 +45,12 @@
 
             <% if @single_pick_criteria.present? %>
               <div class="mt-8">
-                <h2 class="text-lg font-semibold text-gray-900 text-center">Голоса по критериям</h2>
+                <h2 class="text-lg font-semibold text-gray-900 text-center"><%= t('.criterion_votes_title') %></h2>
 
                 <div class="mt-4 mx-auto max-w-lg rounded border bg-white overflow-hidden">
                   <div class="grid grid-cols-2 border-b bg-gray-50 px-3 py-2 text-sm font-medium text-gray-700">
-                    <div>Критерий</div>
-                    <div>Голоса</div>
+                    <div><%= t('.criterion_header') %></div>
+                    <div><%= t('.votes_header') %></div>
                   </div>
 
                   <div class="divide-y">
@@ -84,7 +84,7 @@
 
               <%# fallback, если jam не найден %>
               <% if jam.nil? %>
-                <p class="mt-4 text-center text-sm text-gray-500">Джем не найден.</p>
+                <p class="mt-4 text-center text-sm text-gray-500"><%= t('.jam_not_found') %></p>
               <% else %>
                 <% can_vote = jam.can_vote_as_jury?(current_user) || jam.can_vote_as_audience?(current_user) %>
 
@@ -105,7 +105,7 @@
                 %>
 
                 <div class="mt-6 text-center">
-                  <h2 class="text-lg font-semibold">Оценка по критериям</h2>
+                  <h2 class="text-lg font-semibold"><%= t('.your_criteria_score') %></h2>
 
                   <p class="text-xl font-bold text-gray-900 inline-flex items-center mt-2">
                     <%= my_overall %>
@@ -118,13 +118,13 @@
                   </p>
 
                   <% if can_vote %>
-                    <%= button_to (my_overall > 0 ? "Изменить оценки по критериям" : "Оценить по критериям"),
+                    <%= button_to (my_overall > 0 ? t('.edit_criteria_scores') : t('.rate_by_criteria')),
                                   new_jam_game_vote_path(jam, @game),
                                   method: :get,
                                   class: "bg-indigo-600 text-white px-4 py-2 rounded-lg mt-4" %>
                   <% else %>
                     <p class="mt-4 text-sm text-gray-500">
-                      Оценивание для вас недоступно (закрыто или нет прав).
+                      <%= t('.voting_unavailable') %>
                     </p>
                   <% end %>
                 </div>
@@ -194,7 +194,7 @@
           <% if @jam_id.present? && @reviews.present? %>
             <div class="mt-8 text-center">
               <h2 class="text-lg font-semibold">
-                Оценки участников
+                <%= t('.participant_scores') %>
               </h2>
 
               <% grouped = @reviews.group_by(&:user) %>
@@ -217,7 +217,7 @@
                       </p>
 
                       <p class="text-sm text-gray-500">
-                        Общая оценка: <%= overall.round(1) %>
+                        <%= t('.overall_score') %> <%= overall.round(1) %>
                       </p>
                     </div>
                   </div>

--- a/app/views/games/showcase.html.erb
+++ b/app/views/games/showcase.html.erb
@@ -1,8 +1,8 @@
 <div class="bg-white" data-controller="games">
   <div class="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
     <div class="flex justify-between items-center mb-8">
-      <h2 class="text-3xl font-bold tracking-tight text-gray-900">Игры</h2>
-      <%= button_to "Создать игру", games_new_path, method: :get,
+      <h2 class="text-3xl font-bold tracking-tight text-gray-900"><%= t('layouts.header.games') %></h2>
+      <%= button_to t('games.showcase.create'), games_new_path, method: :get,
                     class: "rounded-md bg-indigo-600 py-2 px-4 text-sm font-medium text-white shadow
                      hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500
                       focus:ring-offset-2 transition duration-300" %>
@@ -13,11 +13,11 @@
         <button data-action="click->games#toggleGames"
                 data-view="all"
                 data-games-target="showAll"
-                class="text-lg text-gray-400 hover:text-gray-800 font-medium transition duration-200">Все игры</button>
+                class="text-lg text-gray-400 hover:text-gray-800 font-medium transition duration-200"><%= t('.all_games') %></button>
         <button data-action="click->games#toggleGames"
                 data-view="mine"
                 data-games-target="showMine"
-                class="text-lg text-gray-400 hover:text-gray-800 font-medium transition duration-200">Мои игры</button>
+                class="text-lg text-gray-400 hover:text-gray-800 font-medium transition duration-200"><%= t('.my_games') %></button>
       </div>
     <% end %>
 
@@ -40,7 +40,7 @@
       </div>
 
       <div class="mt-4">
-        <label class="block text-sm font-medium text-white">Теги</label>
+        <label class="block text-sm font-medium text-white"><%= t('games.form.tags') %></label>
         <div class="mt-1 grid grid-cols-3 gap-2 sm:grid-cols-4 lg:grid-cols-10">
           <% @tags.each do |tag| %>
             <label data-games-target="label"
@@ -87,35 +87,35 @@
     </div>
 
     <div data-games-target="allGames">
-      <h3 class="text-xl font-semibold my-4">Все игры</h3>
+      <h3 class="text-xl font-semibold my-4"><%= t('.all_games') %></h3>
       <% if @games.present? %>
         <%= render partial: 'helpers/showcase_grid', locals: { items: @games } %>
         <%= render partial: 'helpers/pagy' if @pagy.pages > 1 %>
     <% else %>
-        <p class="text-gray-600 mt-2">Нет доступных игр.</p>
+        <p class="text-gray-600 mt-2"><%= t('.no_games_available') %></p>
       <% end %>
     </div>
 
     <div data-games-target="myGames" class="mt-6 hidden">
-      <h3 class="text-xl font-semibold my-4">Мои игры</h3>
+      <h3 class="text-xl font-semibold my-4"><%= t('.my_games') %></h3>
       <% if @games_accepted.present? %>
         <%= render partial: 'helpers/showcase_grid', locals: { items: @games_accepted } %>
       <% else %>
-        <p class="text-gray-600 mt-2">У вас нет принятых игр.</p>
+        <p class="text-gray-600 mt-2"><%= t('.no_accepted') %></p>
       <% end %>
 
-      <h3 class="text-xl font-semibold my-4">Игры на модерации</h3>
+      <h3 class="text-xl font-semibold my-4"><%= t('.under_moderation') %></h3>
       <% if @games_under_moderation.present? %>
         <%= render partial: 'helpers/showcase_grid', locals: { items: @games_under_moderation } %>
       <% else %>
-        <p class="text-gray-600 mt-2">У вас нет игр на модерации.</p>
+        <p class="text-gray-600 mt-2"><%= t('.no_under_moderation') %></p>
       <% end %>
 
-      <h3 class="text-xl font-semibold my-4">Отклоненные игры</h3>
+      <h3 class="text-xl font-semibold my-4"><%= t('.rejected') %></h3>
       <% if @games_rejected.present? %>
         <%= render partial: 'helpers/showcase_grid', locals: { items: @games_rejected } %>
       <% else %>
-        <p class="text-gray-600 mt-2">У вас нет отклоненных игр.</p>
+        <p class="text-gray-600 mt-2"><%= t('.no_rejected') %></p>
       <% end %>
     </div>
   </div>

--- a/app/views/helpers/_gray_search.html.erb
+++ b/app/views/helpers/_gray_search.html.erb
@@ -157,7 +157,7 @@
 
                       <% if current_user && contributor.user_id == current_user.id && contributor.status == "pending" %>
                         <div class="mt-2">
-                          <%= button_to "Принять приглашение",
+                          <%= button_to t('helpers.gray_search.accept_jury_invite'),
                                         accept_contributor_invite_jam_path(jam, contributor_id: contributor.id),
                                         method: :patch,
                                         class: "rounded bg-indigo-600 px-3 py-1 text-white hover:bg-indigo-700" %>

--- a/app/views/helpers/_report_form.html.erb
+++ b/app/views/helpers/_report_form.html.erb
@@ -1,29 +1,33 @@
-<div data-controller="report">
+<div data-controller="report"
+     data-report-submitting-value="<%= t('.submitting') %>"
+     data-report-other-reason-value="<%= t('.other_reason') %>"
+     data-report-generic-error-value="<%= t('.generic_error') %>"
+     data-report-submit-value="<%= t('.submit') %>">
   <button
     class="mt-4 flex w-50 justify-center rounded-md border border-transparent bg-red-500 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
     data-action="click->report#open">
-    Пожаловаться
+    <%= t '.open_btn' %>
   </button>
 
   <div
     class="fixed inset-0 flex items-center justify-center bg-gray-900 bg-opacity-50 hidden"
     data-report-target="modal">
     <div class="bg-white p-6 rounded-lg shadow-lg w-full max-w-md">
-      <h2 class="text-xl font-bold mb-4 text-gray-800">Оставить жалобу</h2>
+      <h2 class="text-xl font-bold mb-4 text-gray-800"><%= t '.title' %></h2>
       <form data-action="submit->report#submit" action="/reports" method="post">
         <div class="mb-4">
-          <label for="complaint" class="block text-gray-700 font-medium mb-2">Причина жалобы</label>
+          <label for="complaint" class="block text-gray-700 font-medium mb-2"><%= t '.reason_label' %></label>
           <textarea
             id="complaint"
             name="reason"
             rows="4"
             maxlength="300"
             class="w-full p-2 border border-gray-300 rounded focus:ring-2 focus:ring-red-500 focus:outline-none resize-none"
-            placeholder="Опишите вашу жалобу"
+            placeholder="<%= t '.reason_placeholder' %>"
             data-action="input->report#validateLength"
             data-report-target="textarea"
             required></textarea>
-          <p class="text-red-500 text-sm hidden" data-report-target="warning">Максимум 300 символов!</p>
+          <p class="text-red-500 text-sm hidden" data-report-target="warning"><%= t '.max_length' %></p>
         </div>
         <input type="hidden" name="reportable_type" value="<%= report_item.class.name %>">
         <input type="hidden" name="reportable_id" value=<%= report_item.id %>>
@@ -32,12 +36,12 @@
             type="button"
             class="px-4 py-2 bg-gray-300 text-gray-700 rounded hover:bg-gray-400 transition"
             data-action="click->report#close">
-            Отмена
+            <%= t('buttons.cancel') %>
           </button>
           <button
             type="submit"
             class="px-4 py-2 bg-red-500 text-white rounded hover:bg-red-600 transition">
-            Отправить
+            <%= t '.submit' %>
           </button>
         </div>
       </form>
@@ -48,12 +52,12 @@
     class="fixed inset-0 flex items-center justify-center bg-gray-900 bg-opacity-50 hidden"
     data-report-target="successModal">
     <div class="bg-white p-6 rounded-lg shadow-lg w-full max-w-md">
-      <h2 class="text-xl font-bold mb-4 text-green-600">Жалоба отправлена!</h2>
-      <p class="text-gray-700 mb-4">Спасибо за вашу жалобу. Мы рассмотрим её в ближайшее время.</p>
+      <h2 class="text-xl font-bold mb-4 text-green-600"><%= t '.success_title' %></h2>
+      <p class="text-gray-700 mb-4"><%= t '.success_body' %></p>
       <button
         class="px-4 py-2 bg-green-500 text-white rounded hover:bg-green-600 transition"
         data-action="click->report#closeSuccess">
-        Закрыть
+        <%= t('buttons.close') %>
       </button>
     </div>
   </div>
@@ -62,12 +66,12 @@
     class="fixed inset-0 flex items-center justify-center bg-gray-900 bg-opacity-50 hidden"
     data-report-target="errorModal">
     <div class="bg-white p-6 rounded-lg shadow-lg w-full max-w-md">
-      <h2 class="text-xl font-bold mb-4 text-red-600">Ошибка</h2>
+      <h2 class="text-xl font-bold mb-4 text-red-600"><%= t '.error_title' %></h2>
       <p class="text-gray-700 mb-4" data-report-target="errorMessage"></p>
       <button
         class="px-4 py-2 bg-red-500 text-white rounded hover:bg-red-600 transition"
         data-action="click->report#closeError click->report#close">
-        Закрыть
+        <%= t('buttons.close') %>
       </button>
     </div>
   </div>

--- a/app/views/helpers/_showcase_grid.html.erb
+++ b/app/views/helpers/_showcase_grid.html.erb
@@ -29,7 +29,7 @@
             <%= item.author.name %>
           </a>
         <% else %>
-          <p class="mt-2 text-gray-600 text-sm">Автор не найден</p>
+          <p class="mt-2 text-gray-600 text-sm"><%= t 'games.showcase.no_author' %></p>
         <% end %>
       </div>
     </div>

--- a/app/views/jam_criterion_picks/_pick_block.html.erb
+++ b/app/views/jam_criterion_picks/_pick_block.html.erb
@@ -3,22 +3,22 @@
 
 <div class="mt-4 flex items-center justify-between">
   <% if current_pick&.game_id == game.id %>
-    <span class="text-sm text-green-600 font-medium">Вы выбрали эту игру</span>
+    <span class="text-sm text-green-600 font-medium"><%= t('.you_picked') %></span>
 
-    <%= link_to "Отменить",
+    <%= link_to t('.cancel'),
                 jam_jam_criterion_pick_path(jam, current_pick, game_id: game.id),
                 data: { turbo_method: :delete, turbo_frame: dom_id(criterion, :pick_block) },
                 class: "text-sm text-red-600 hover:text-red-800 underline" %>
   <% else %>
     <% if current_pick.present? %>
       <span class="text-sm text-gray-500">
-        Сейчас выбрано: <%= current_pick.game.name rescue "другая игра" %>
+        <%= t('.currently_picked') %> <%= current_pick.game.name rescue t('.other_game') %>
       </span>
     <% else %>
-      <span class="text-sm text-gray-500">Выбор не сделан</span>
+      <span class="text-sm text-gray-500"><%= t('.no_pick') %></span>
     <% end %>
 
-    <%= link_to (current_pick.present? ? "Выбрать вместо" : "Выбрать игру"),
+    <%= link_to (current_pick.present? ? t('.pick_instead') : t('.pick_game')),
                 jam_jam_criterion_picks_path(jam,
                                              jam_criterion_id: criterion.id,
                                              game_id: game.id,

--- a/app/views/jam_votes/new.html.erb
+++ b/app/views/jam_votes/new.html.erb
@@ -5,11 +5,11 @@
       <div class="flex justify-between items-center">
         <div>
           <h1 class="text-2xl font-medium text-gray-900 break-all"><%= @game.name %></h1>
-          <p class="text-sm text-gray-500">Джем: <%= @jam.name %></p>
+          <p class="text-sm text-gray-500"><%= t('.jam_label') %> <%= @jam.name %></p>
         </div>
 
         <div class="text-right">
-          <p class="text-sm text-gray-500">Общая оценка (по критериям)</p>
+          <p class="text-sm text-gray-500"><%= t('.overall_score') %></p>
           <p id="overall_preview" class="text-2xl font-bold text-gray-900">0.0</p>
         </div>
       </div>
@@ -30,7 +30,7 @@
                   <h2 class="text-lg font-semibold text-gray-900"><%= criterion.title %></h2>
 
                   <% if criterion.kind == "manually_ranked" %>
-                    <div class="text-sm text-gray-500">1 голос</div>
+                    <div class="text-sm text-gray-500"><%= t('.one_vote') %></div>
                   <% else %>
                     <div class="text-sm text-gray-500">0..5</div>
                   <% end %>
@@ -69,7 +69,7 @@
                   <div class="mt-4">
         <textarea
           class="w-full p-3 border-2 border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 placeholder-gray-400"
-          placeholder="Комментарий (необязательно)"
+          placeholder="<%= t('.comment_placeholder') %>"
           rows="3"
           maxlength="1000"
           name="comments[<%= criterion.id %>]"
@@ -89,7 +89,7 @@
 
           <button type="submit"
                   class="bg-indigo-600 text-white px-4 py-2 rounded-lg mt-6">
-            Сохранить
+            <%= t('buttons.save') %>
           </button>
         <% end %>
       </div>

--- a/app/views/jams/_form.html.erb
+++ b/app/views/jams/_form.html.erb
@@ -1,4 +1,7 @@
-<div data-controller="jams">
+<div data-controller="jams"
+     data-jams-invalid-dates-value="<%= t('controllers.jams.invalid_dates') %>"
+     data-jams-deadline-before-start-value="<%= t('controllers.jams.date_deadline_before_start') %>"
+     data-jams-end-before-deadline-value="<%= t('controllers.jams.date_end_before_deadline') %>">
   <%= form_with(model: @jam, url: path, local: true) do |f| %>
     <div class="mt-4">
       <%= f.label :name, t('.name'), class: "block text-sm font-medium text-white" %>
@@ -66,11 +69,11 @@
         <div class="text-gray-500 border-dashed border-2 border-gray-400 p-6 text-center rounded-md relative">
           <% if @jam && @jam.cover.attached? && @jam.cover.persisted? %>
             <img data-jams-target="coverPreviewImg" id="cover-preview-img" src="<%= url_for(@jam.cover) %>"
-                 alt="Предварительный просмотр обложки"
+                 alt="<%= t('.cover_preview_alt') %>"
                  class="mt-4 w-full h-auto object-cover rounded-md">
           <% else %>
             <img data-jams-target="coverPreviewImg" id="cover-preview-img" src="#"
-                 alt="Предварительный просмотр обложки"
+                 alt="<%= t('.cover_preview_alt') %>"
                  class="mt-4 hidden w-full h-auto object-cover rounded-md">
           <% end %>
           <%= f.file_field :cover, id: "cover-input",
@@ -94,11 +97,11 @@
         <div class="text-gray-500 border-dashed border-2 border-gray-400 p-6 text-center rounded-md relative">
           <% if @jam && @jam.logo.attached? && @jam.logo.persisted? %>
             <img data-jams-target="logoPreviewImg" id="logo-preview-img" src="<%= url_for(@jam.logo) %>"
-                 alt="Предварительный просмотр логотипа"
+                 alt="<%= t('.logo_preview_alt') %>"
                  class="mt-4 w-full h-auto object-cover rounded-md">
           <% else %>
             <img data-jams-target="logoPreviewImg" id="logo-preview-img" src="#"
-                 alt="Предварительный просмотр логотипа"
+                 alt="<%= t('.logo_preview_alt') %>"
                  class="mt-4 hidden w-full h-auto object-cover rounded-md">
           <% end %>
           <%= f.file_field :logo, id: "logo-input",
@@ -140,7 +143,7 @@
                    class: "mt-4 flex w-full justify-center rounded-md border
                      border-transparent bg-indigo-600 py-2 px-4 text-sm font-medium text-white shadow-sm
                      hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2",
-                   data: { turbo_submits_with: "Создаем...", turbo_track: "dynamic" } %>
+                   data: { turbo_submits_with: t('.submitting'), turbo_track: "dynamic" } %>
 
     <div class='blur-background hidden' id='blur'>
       <div class="loading-spinner hidden" id="loading">

--- a/app/views/jams/_jury_contributors_table.html.erb
+++ b/app/views/jams/_jury_contributors_table.html.erb
@@ -1,16 +1,16 @@
 <div class="p-4 rounded border bg-white">
-  <h2 class="text-lg font-medium mb-3">Участники (host/admin/judge)</h2>
+  <h2 class="text-lg font-medium mb-3"><%= t('jams.jury_contributors_table.title') %></h2>
 
   <%= form_with url: bulk_update_contributors_jam_path(jam), method: :patch do %>
     <table class="w-full text-sm">
       <thead>
       <tr class="text-left border-b">
-        <th class="py-2">User</th>
-        <th class="py-2">Status</th>
-        <th class="py-2">Host</th>
-        <th class="py-2">Admin</th>
-        <th class="py-2">Judge</th>
-        <th class="py-2">Actions</th>
+        <th class="py-2"><%= t('jams.jury_contributors_table.user') %></th>
+        <th class="py-2"><%= t('jams.jury_contributors_table.status') %></th>
+        <th class="py-2"><%= t('jams.jury_contributors_table.host') %></th>
+        <th class="py-2"><%= t('jams.jury_contributors_table.admin') %></th>
+        <th class="py-2"><%= t('jams.jury_contributors_table.judge') %></th>
+        <th class="py-2"><%= t('jams.jury_contributors_table.actions') %></th>
       </tr>
       </thead>
 
@@ -39,13 +39,13 @@
           </td>
 
           <td class="py-2 flex gap-2">
-            <%= button_to "Remove",
+            <%= button_to t('jams.jury_contributors_table.remove'),
                           remove_contributor_jam_path(jam, contributor_id: c.id),
                           method: :delete,
                           class: "rounded bg-red-600 px-3 py-1 text-white hover:bg-red-700" %>
 
             <% if c.status == "pending" %>
-              <span class="text-gray-400">(pending)</span>
+              <span class="text-gray-400"><%= t('jams.jury_contributors_table.pending') %></span>
             <% end %>
           </td>
         </tr>
@@ -54,7 +54,7 @@
     </table>
 
     <div class="mt-4">
-      <%= submit_tag "Save all", class: "rounded bg-indigo-600 px-4 py-2 text-white hover:bg-indigo-700" %>
+      <%= submit_tag t('jams.jury_contributors_table.save_all'), class: "rounded bg-indigo-600 px-4 py-2 text-white hover:bg-indigo-700" %>
     </div>
   <% end %>
 </div>

--- a/app/views/jams/_jury_search_results.html.erb
+++ b/app/views/jams/_jury_search_results.html.erb
@@ -1,5 +1,5 @@
 <% if users.empty? %>
-  <div class="mt-3 text-sm text-gray-500">Ничего не найдено</div>
+  <div class="mt-3 text-sm text-gray-500"><%= t('jams.jury_search_results.empty') %></div>
 <% else %>
   <div class="mt-3 divide-y rounded border bg-white">
     <% users.each do |u| %>
@@ -9,7 +9,7 @@
           <div class="text-sm text-gray-500"><%= u.email %></div>
         </div>
 
-        <%= button_to "Пригласить",
+        <%= button_to t('jams.jury_search_results.invite'),
                       jury_invite_jam_path(jam, user_id: u.id),
                       method: :post,
                       class: "rounded bg-indigo-600 px-3 py-1 text-white hover:bg-indigo-700" %>

--- a/app/views/jams/_modal_content.html.erb
+++ b/app/views/jams/_modal_content.html.erb
@@ -1,7 +1,11 @@
 <div class="fixed inset-0 flex items-center justify-center bg-gray-950 bg-opacity-60">
-  <div id="modalContent" class="bg-white relative rounded-lg shadow-lg p-6 w-full h-max sm:w-1/2">
+  <div id="modalContent" class="bg-white relative rounded-lg shadow-lg p-6 w-full h-max sm:w-1/2"
+       data-choose-title="<%= t('jams.modal_content.title') %>"
+       data-your-games-title="<%= t('jams.modal_content.your_games') %>"
+       data-your-games-hint="<%= t('jams.modal_content.your_games_hint') %>"
+       data-default-description="This is a modal dialog. You can put any content here.">
     <h2 id="modalTitle" class="text-lg font-medium text-gray-900">
-      <%= t '.title' %>
+      <%= t 'jams.modal_content.title' %>
     </h2>
     <p id="modalDescription" hidden class="mt-2 text-sm text-gray-600">This is a modal dialog. You can put any content
       here.</p>
@@ -30,22 +34,28 @@
         }
 
         function alternateContent() {
-            title = document.getElementById("modalTitle");
-            description = document.getElementById("modalDescription");
+            const modal = document.getElementById("modalContent");
+            const title = document.getElementById("modalTitle");
+            const description = document.getElementById("modalDescription");
 
-            if (title.innerText === "Выберите") {
-                title.innerText = "Ваши игры";
-                description.innerText = "Выберите одну из ваших игр:";
+            const chooseTitle = modal.dataset.chooseTitle;
+            const yourGamesTitle = modal.dataset.yourGamesTitle;
+            const yourGamesHint = modal.dataset.yourGamesHint;
+            const defaultDescription = modal.dataset.defaultDescription;
+
+            if (title.innerText === chooseTitle) {
+                title.innerText = yourGamesTitle;
+                description.innerText = yourGamesHint;
             } else {
-                title.innerText = "Выберите";
-                description.innerText = "This is a modal dialog. You can put any content here.";
+                title.innerText = chooseTitle;
+                description.innerText = defaultDescription;
             }
             description.toggleAttribute('hidden')
         }
     </script>
     <div id='buttons' class="mt-4 flex flex-col items-center lg:flex-row lg:justify-center space-x-0 lg:space-x-3 lg:space-y-0 space-y-3">
       <div class="min-w-max w-full md:w-2/3">
-        <%= button_to t('.add_new'), game_submission_path(@jam), method: :get,
+        <%= button_to t('jams.modal_content.add_new'), game_submission_path(@jam), method: :get,
                       class: "w-full h-20 sm:h-14 lg:h-10 sm:h-14 lg:h-10 rounded-md border border-transparent bg-indigo-600 py-2 px-4 text-sm
                  font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2" %>
       </div>
@@ -53,7 +63,7 @@
         <button id="button2" onclick="alternateShown('buttons', 'games'); toggleWidth(); alternateContent()"
                 class="w-full h-20 sm:h-14 lg:h-10 rounded-md border border-transparent bg-gray-300 py-2 px-4 text-sm
                 font-medium text-black shadow-sm hover:bg-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2">
-          <%= t '.add_existing' %>
+          <%= t 'jams.modal_content.add_existing' %>
         </button>
       </div>
     </div>

--- a/app/views/jams/_nominations_winners.html.erb
+++ b/app/views/jams/_nominations_winners.html.erb
@@ -1,8 +1,8 @@
 <div class="mt-8 p-4 rounded border bg-white">
-  <h2 class="text-xl font-medium mb-2">Победители по номинациям</h2>
+  <h2 class="text-xl font-medium mb-2"><%= t('jams.nominations_winners.title') %></h2>
 
   <% if nominations.empty? %>
-    <div class="text-sm text-gray-500">Номинаций нет</div>
+    <div class="text-sm text-gray-500"><%= t('jams.nominations_winners.empty') %></div>
   <% else %>
     <div class="space-y-3">
       <% nominations.each do |n| %>
@@ -13,7 +13,7 @@
           <input type="hidden" name="nominations_winners[][id]" value="<%= n.id %>">
 
           <select name="nominations_winners[][winner_game_id]" class="rounded border px-3 py-2">
-            <option value="">— не выбрано —</option>
+            <option value=""><%= t('jams.nominations_winners.not_selected') %></option>
             <% games.each do |g| %>
               <option value="<%= g.id %>" <%= "selected" if n.winner_game_id == g.id %>>
                 <%= g.name %>

--- a/app/views/jams/_showcase.html.erb
+++ b/app/views/jams/_showcase.html.erb
@@ -1,8 +1,8 @@
 <div class="bg-white">
   <div class="mx-auto max-w-2xl px-4 py-16 sm:px-6 lg:max-w-7xl lg:px-8">
     <div class="flex justify-between items-center">
-      <h2 class="text-2xl font-bold tracking-tight text-gray-900">Каталог джемов</h2>
-      <%= button_to "Создать джем", jams_new_path, method: :get,
+      <h2 class="text-2xl font-bold tracking-tight text-gray-900"><%= t('jams.showcase.title') %></h2>
+      <%= button_to t('jams.showcase.btn'), jams_new_path, method: :get,
                     class: "rounded-md border border-transparent bg-indigo-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2" %>
     </div>
     <div class="mt-6 grid grid-cols-1 gap-x-6 gap-y-10 sm:grid-cols-2 lg:grid-cols-4 xl:gap-x-8">
@@ -32,7 +32,7 @@
                 <%= jam.author.name %>
               </a>
             <% else %>
-              <p>Автор не найден</p>
+              <p><%= t('jams.showcase.no_author') %></p>
             <% end %>
           </div>
         </div>

--- a/app/views/jams/_showcase_grid.html.erb
+++ b/app/views/jams/_showcase_grid.html.erb
@@ -39,26 +39,26 @@
 
         <div class="mt-4 space-y-2 text-sm text-gray-700">
           <div>
-            <span class="font-medium text-gray-900">Начало:</span>
+            <span class="font-medium text-gray-900"><%= t('jams.showcase_grid.start') %></span>
             <%= jam.start_date&.strftime("%d.%m.%Y") %>
           </div>
 
           <div>
-            <span class="font-medium text-gray-900">Приём работ до:</span>
+            <span class="font-medium text-gray-900"><%= t('jams.showcase_grid.deadline') %></span>
             <%= jam.deadline&.strftime("%d.%m.%Y") %>
           </div>
 
           <div>
-            <span class="font-medium text-gray-900">Создатель:</span>
+            <span class="font-medium text-gray-900"><%= t('jams.showcase_grid.creator') %></span>
             <% if jam.author.present? %>
               <%= link_to jam.author.name, user_profile_path(jam.author), class: "text-indigo-600 hover:text-indigo-900 break-all" %>
             <% else %>
-              <span>Автор не найден</span>
+              <span><%= t('jams.showcase_grid.no_author') %></span>
             <% end %>
           </div>
 
           <div>
-            <span class="font-medium text-gray-900">Хосты:</span>
+            <span class="font-medium text-gray-900"><%= t('jams.showcase_grid.hosts') %></span>
             <% hosts = jam.hosts %>
             <% if hosts.any? %>
               <div class="mt-1 flex flex-wrap gap-2">

--- a/app/views/jams/jury_settings.html.erb
+++ b/app/views/jams/jury_settings.html.erb
@@ -1,26 +1,27 @@
 <div class="mx-auto max-w-5xl px-4 py-8">
-  <h1 class="text-2xl font-semibold mb-6">Настройки жюри</h1>
+  <h1 class="text-2xl font-semibold mb-6"><%= t('.title') %></h1>
 
   <div class="mb-8 p-4 rounded border bg-white">
-    <h2 class="text-lg font-medium mb-3">Пригласить пользователя</h2>
+    <h2 class="text-lg font-medium mb-3"><%= t('.invite_title') %></h2>
 
-    <label class="block text-sm font-medium text-gray-700">Поиск пользователя</label>
+    <label class="block text-sm font-medium text-gray-700"><%= t('.search_user_label') %></label>
 
     <%= form_with url: jury_search_jam_path(@jam),
                   method: :get,
                   data: {
-                    controller: "autosubmit"
+                    controller: "autosubmit",
+                    autosubmit_too_short_value: t('.search_too_short')
                   } do |f| %>
 
       <%= f.text_field :q,
-                       placeholder: "Имя или email",
+                       placeholder: t('.search_placeholder'),
                        class: "mt-2 w-full rounded border px-3 py-2",
                        data: { action: "input->autosubmit#submit" } %>
     <% end %>
 
     <turbo-frame id="jury_search_results">
       <div class="mt-3 text-sm text-gray-500">
-        Начните вводить имя или email…
+        <%= t('.search_prompt') %>
       </div>
     </turbo-frame>
   </div>

--- a/app/views/jams/rating_settings.html.erb
+++ b/app/views/jams/rating_settings.html.erb
@@ -1,35 +1,35 @@
 <div class="mx-auto max-w-3xl px-4 py-8">
-  <h1 class="text-2xl font-semibold mb-6">Настройки оценок</h1>
+  <h1 class="text-2xl font-semibold mb-6"><%= t('.title') %></h1>
 
   <div class="mb-6">
     <%= form_with model: @setting, url: rating_settings_jam_path(@jam), method: :patch do |f| %>
       <div class="space-y-4">
         <div class="flex items-center gap-3">
           <%= f.check_box :jury_enabled %>
-          <%= f.label :jury_enabled, "Жюри (да/нет)" %>
+          <%= f.label :jury_enabled, t('.jury_enabled_label') %>
         </div>
 
         <div class="flex items-center gap-3">
           <%= f.check_box :audience_enabled %>
-          <%= f.label :audience_enabled, "Аудитория (да/нет)" %>
+          <%= f.label :audience_enabled, t('.audience_enabled_label') %>
         </div>
 
-        <p class="text-sm text-cyan-500">Нельзя выбрать два раза “нет”</p>
+        <p class="text-sm text-cyan-500"><%= t('.both_disabled_hint') %></p>
 
         <hr class="my-6"/>
 
-        <h2 class="text-xl font-medium">Критерии оценивания</h2>
-        <p class="text-sm text-gray-500 mb-2">Название критерия (оценка всегда 0..5)</p>
+        <h2 class="text-xl font-medium"><%= t('.criteria_title') %></h2>
+        <p class="text-sm text-gray-500 mb-2"><%= t('.criteria_hint') %></p>
 
         <div class="space-y-3">
           <% 5.times do |i| %>
             <% c = @criteria[i] %>
             <div class="flex gap-3">
               <input type="hidden" name="criteria[][id]" value="<%= c&.id %>">
-              <input name="criteria[][title]" value="<%= c&.title.to_s %>" class="w-full rounded border px-3 py-2" placeholder="Например: Геймплей" />
+              <input name="criteria[][title]" value="<%= c&.title.to_s %>" class="w-full rounded border px-3 py-2" placeholder="<%= t('.criterion_placeholder') %>" />
               <select name="criteria[][kind]" class="rounded border px-3 py-2">
-                <option value="voted_on" <%= "selected" if c&.kind == "voted_on" %>>Voted on</option>
-                <option value="manually_ranked" <%= "selected" if c&.kind == "manually_ranked" %>>1 vote per game</option>
+                <option value="voted_on" <%= "selected" if c&.kind == "voted_on" %>><%= t('.kind_voted_on') %></option>
+                <option value="manually_ranked" <%= "selected" if c&.kind == "manually_ranked" %>><%= t('.kind_manually_ranked') %></option>
               </select>
             </div>
           <% end %>
@@ -37,15 +37,15 @@
 
         <hr class="my-6"/>
 
-        <h2 class="text-xl font-medium">Номинации</h2>
-        <p class="text-sm text-gray-500 mb-2">Номинацию присваивает админ в конце</p>
+        <h2 class="text-xl font-medium"><%= t('.nominations_title') %></h2>
+        <p class="text-sm text-gray-500 mb-2"><%= t('.nominations_hint') %></p>
 
         <div class="space-y-3">
           <% 5.times do |i| %>
             <% n = @nominations[i] %>
             <div class="flex gap-3">
               <input type="hidden" name="nominations[][id]" value="<%= n&.id %>">
-              <input name="nominations[][title]" value="<%= n&.title.to_s %>" class="w-full rounded border px-3 py-2" placeholder="Например: Лучший арт" />
+              <input name="nominations[][title]" value="<%= n&.title.to_s %>" class="w-full rounded border px-3 py-2" placeholder="<%= t('.nomination_placeholder') %>" />
             </div>
           <% end %>
         </div>
@@ -54,7 +54,7 @@
                    locals: { jam: @jam, nominations: @nominations, games: @games } %>
 
         <div class="pt-6">
-          <%= f.submit "Сохранить", class: "rounded bg-indigo-600 px-4 py-2 text-white hover:bg-indigo-700" %>
+          <%= f.submit t('buttons.save'), class: "rounded bg-indigo-600 px-4 py-2 text-white hover:bg-indigo-700" %>
         </div>
       </div>
     <% end %>

--- a/app/views/jams/show.html.erb
+++ b/app/views/jams/show.html.erb
@@ -7,8 +7,8 @@
             <h1 class="text-2xl font-medium text-gray-900 break-all"><%= @jam.name %></h1>
           </div>
           <% if @jam.status != 1 %>
-            <p class="mt-2 text-red-400 sm:text-sm">Данный джем
-              <%= @jam.status == 0 ? 'находится на модерации' : 'отклонен модератором' %>
+            <p class="mt-2 text-red-400 sm:text-sm"><%= t('.this_jam') %>
+              <%= @jam.status == 0 ? t('.status_pending') : t('.status_rejected') %>
             </p>
           <% end %>
         </div>
@@ -67,36 +67,36 @@
 
           <div class="mt-10">
             <h2 class="text-lg font-medium text-gray-900">
-              Информация о джеме
+              <%= t('.jam_info') %>
             </h2>
 
             <div class="mt-4 space-y-3 text-gray-700">
               <div>
-                <span class="font-medium text-gray-900">Дата начала:</span>
+                <span class="font-medium text-gray-900"><%= t('.start_date') %></span>
                 <span><%= @jam.start_date&.strftime("%d.%m.%Y") %></span>
               </div>
 
               <div>
-                <span class="font-medium text-gray-900">Окончание приёма работ:</span>
+                <span class="font-medium text-gray-900"><%= t('.deadline') %></span>
                 <span><%= @jam.deadline&.strftime("%d.%m.%Y") %></span>
               </div>
 
               <div>
-                <span class="font-medium text-gray-900">Окончание оценивания:</span>
+                <span class="font-medium text-gray-900"><%= t('.end_date') %></span>
                 <span><%= @jam.end_date&.strftime("%d.%m.%Y") %></span>
               </div>
 
               <div>
-                <span class="font-medium text-gray-900">Создатель:</span>
+                <span class="font-medium text-gray-900"><%= t('.creator') %></span>
                 <% if @jam.author.present? %>
                   <%= link_to @jam.author.name, user_profile_path(@jam.author), class: "text-indigo-600 hover:text-indigo-900" %>
                 <% else %>
-                  <span class="text-gray-500">Автор не найден</span>
+                  <span class="text-gray-500"><%= t('.no_author') %></span>
                 <% end %>
               </div>
 
               <div>
-                <span class="font-medium text-gray-900">Хосты:</span>
+                <span class="font-medium text-gray-900"><%= t('.hosts') %></span>
                 <% hosts = @jam.hosts %>
                 <% if hosts.any? %>
                   <div class="mt-1 flex flex-wrap gap-2">
@@ -106,7 +106,7 @@
                     <% end %>
                   </div>
                 <% else %>
-                  <span class="text-gray-500">Хосты не назначены</span>
+                  <span class="text-gray-500"><%= t('.no_hosts') %></span>
                 <% end %>
               </div>
             </div>
@@ -116,7 +116,7 @@
 
           <% if winners.any? %>
             <div class="mt-10 rounded-lg border bg-white p-4">
-              <h2 class="text-lg font-semibold text-gray-900">Победители по номинациям</h2>
+              <h2 class="text-lg font-semibold text-gray-900"><%= t('.nominations_winners') %></h2>
 
               <div class="mt-4 space-y-3">
                 <% winners.each do |n| %>
@@ -150,10 +150,10 @@
                           class: "mt-4 flex w-50 justify-center rounded-md border border-transparent bg-red-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2" %>
 
             <% if current_user && @jam.can_configure?(current_user) %>
-              <%= button_to "Настройки оценок", rating_settings_jam_path(@jam), method: :get,
+              <%= button_to t('.rating_settings'), rating_settings_jam_path(@jam), method: :get,
                             class: "mt-4 flex w-50 justify-center rounded-md border border-transparent bg-indigo-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-indigo-700" %>
 
-              <%= button_to "Настройки жюри", jury_settings_jam_path(@jam), method: :get,
+              <%= button_to t('.jury_settings'), jury_settings_jam_path(@jam), method: :get,
                             class: "mt-4 flex w-50 justify-center rounded-md border border-transparent bg-indigo-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-indigo-700" %>
             <% end %>
           <% elsif current_user.present? %>
@@ -197,7 +197,7 @@
                   </button>
                 <% else %>
                   <p class="mt-4 text-sm text-gray-500">
-                    Приём работ завершён. Редактирование и замена игры недоступны.
+                    <%= t('.submission_closed_edit') %>
                   </p>
                 <% end %>
 
@@ -212,7 +212,7 @@
                   </button>
                 <% else %>
                   <p class="mt-4 text-sm text-gray-500">
-                    Приём работ завершён
+                    <%= t('.submission_closed') %>
                   </p>
                 <% end %>
               <% end %>
@@ -222,7 +222,7 @@
                               class: "mt-4 flex w-50 justify-center rounded-md border border-transparent bg-indigo-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2" %>
               <% else %>
                 <p class="mt-4 text-sm text-gray-500">
-                  Приём работ завершён
+                  <%= t('.submission_closed') %>
                 </p>
               <% end %>
             <% end %>

--- a/app/views/jams/show_participants.html.erb
+++ b/app/views/jams/show_participants.html.erb
@@ -10,7 +10,7 @@
           <%= t '.title' %>
         </h2>
         <% if current_user && @jam.can_manage?(current_user) %>
-          <span class="text-sm text-gray-500">(Нажмите "Удалить", чтобы исключить участника)</span>
+          <span class="text-sm text-gray-500"><%= t('.remove_hint') %></span>
         <% end %>
       <% end %>
     </div>
@@ -56,9 +56,9 @@
 
           <% if current_user && @jam.can_manage?(current_user) %>
             <div class="ml-2">
-              <%= button_to "Удалить", remove_participant_jam_path(@jam, user_id: user.id),
+              <%= button_to t('.remove'), remove_participant_jam_path(@jam, user_id: user.id),
                             method: :delete,
-                            data: { confirm: "Вы уверены, что хотите удалить этого участника из джема?" },
+                            data: { confirm: t('.remove_confirm') },
                             class: "text-sm text-red-600 hover:text-red-800 underline" %>
             </div>
           <% end %>

--- a/app/views/jams/show_projects.html.erb
+++ b/app/views/jams/show_projects.html.erb
@@ -5,7 +5,7 @@
         <%= t '.title' %>
       </h2>
       <% if current_user && @jam.can_manage?(current_user) %>
-        <span class="text-sm text-gray-500">(Вы можете удалить проект, нажав на кнопку рядом с игрой)</span>
+        <span class="text-sm text-gray-500"><%= t('.remove_hint') %></span>
       <% end %>
     </div>
     <% unless @games.empty? %>
@@ -100,9 +100,9 @@
 
                 <% if current_user && @jam.can_manage?(current_user) %>
                   <div class="mt-2">
-                    <%= button_to "Удалить проект", remove_project_jam_path(@jam, game_id: game.id),
+                    <%= button_to t('.remove_project'), remove_project_jam_path(@jam, game_id: game.id),
                                   method: :delete,
-                                  data: { confirm: "Вы уверены, что хотите отвязать эту игру от джема?" },
+                                  data: { confirm: t('.remove_project_confirm') },
                                   class: "text-sm text-red-600 hover:text-red-800 underline" %>
                   </div>
                 <% end %>

--- a/app/views/jams/showcase.html.erb
+++ b/app/views/jams/showcase.html.erb
@@ -12,11 +12,11 @@
         <button data-action="click->jams#toggleJams"
                 data-view="all"
                 data-jams-target="showAll"
-                class="text-lg text-gray-400 hover:text-gray-800 font-medium transition duration-200">Все джемы</button>
+                class="text-lg text-gray-400 hover:text-gray-800 font-medium transition duration-200"><%= t('.all_jams') %></button>
         <button data-action="click->jams#toggleJams"
                 data-view="mine"
                 data-jams-target="showMine"
-                class="text-lg text-gray-400 hover:text-gray-800 font-medium transition duration-200">Мои джемы</button>
+                class="text-lg text-gray-400 hover:text-gray-800 font-medium transition duration-200"><%= t('.my_jams') %></button>
       </div>
     <% end %>
     <%= form_with url: jams_showcase_path, method: :get,
@@ -38,7 +38,7 @@
       </div>
 
       <div class="mt-4">
-        <label class="block text-sm font-medium text-white">Теги</label>
+        <label class="block text-sm font-medium text-white"><%= t('jams.form.tags') %></label>
         <div class="mt-1 grid grid-cols-3 gap-2 sm:grid-cols-4 lg:grid-cols-10">
           <% @tags.each do |tag| %>
             <label data-jams-target="label"
@@ -101,25 +101,25 @@
     </div>
 
     <div class="mt-6 hidden" data-jams-target="myJams">
-      <h3 class="text-xl font-semibold my-4">Принятые джемы</h3>
+      <h3 class="text-xl font-semibold my-4"><%= t('.accepted') %></h3>
       <% if @jams_accepted.present? %>
         <%= render partial: 'showcase_grid', locals: { jams: @jams_accepted } %>
       <% else %>
-        <p class="text-gray-600 mt-2">У вас нет принятых джемов.</p>
+        <p class="text-gray-600 mt-2"><%= t('.no_accepted') %></p>
       <% end %>
 
-      <h3 class="text-xl font-semibold my-4">Джемы на модерации</h3>
+      <h3 class="text-xl font-semibold my-4"><%= t('.under_moderation') %></h3>
       <% if @jams_under_moderation.present? %>
         <%= render partial: 'showcase_grid', locals: { jams: @jams_under_moderation } %>
       <% else %>
-        <p class="text-gray-600 mt-2">У вас нет джемов на модерации.</p>
+        <p class="text-gray-600 mt-2"><%= t('.no_under_moderation') %></p>
       <% end %>
 
-      <h3 class="text-xl font-semibold my-4">Отклонённые джемы</h3>
+      <h3 class="text-xl font-semibold my-4"><%= t('.rejected') %></h3>
       <% if @jams_rejected.present? %>
         <%= render partial: 'showcase_grid', locals: { jams: @jams_rejected } %>
       <% else %>
-        <p class="text-gray-600 mt-2">У вас нет отклонённых джемов.</p>
+        <p class="text-gray-600 mt-2"><%= t('.no_rejected') %></p>
       <% end %>
     </div>
 

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,9 +1,9 @@
 <footer class="bg-gray-900">
   <nav class="mx-auto flex max-w-7xl items-center justify-center p-6 lg:px-8" aria-label="Global">
     <div class="lg:flex lg:gap-x-12">
-      <%= link_to t('layouts.header.home'), root_path, class: "text-sm font-semibold leading-6 text-white" %>
-      <%= link_to t('layouts.header.users'), users_path, class: "text-sm font-semibold leading-6 text-white" %>
-      <%= link_to t('layouts.header.games'), games_path, class: "text-sm font-semibold leading-6 text-white" %>
+      <%= link_to t('layouts.header.home'), url_for(:root), class: "text-sm font-semibold leading-6 text-white" %>
+      <%= link_to t('layouts.header.users'), url_for(:users), class: "text-sm font-semibold leading-6 text-white" %>
+      <%= link_to t('layouts.header.games'), url_for(:games_showcase), class: "text-sm font-semibold leading-6 text-white" %>
     </div>
   </nav>
   <div class="flex flex-wrap justify-center items-center gap-4 px-4">

--- a/app/views/layouts/_is_frozen.html.erb
+++ b/app/views/layouts/_is_frozen.html.erb
@@ -3,16 +3,16 @@
        class="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-50 hidden"
        data-freeze-modal-target="modal">
     <div class="bg-white p-6 rounded-lg max-w-lg w-full">
-      <h2 class="text-xl font-bold text-red-500">Вы заморожены!</h2>
-      <p class="mt-4 text-gray-800">Причина: <%= current_user.frozen_reason %></p>
-      <p class="mt-2 text-gray-800">Заморозка была установлена: <%= current_user.frozen_at.strftime("%d-%m-%Y %H:%M") %></p>
-      <p class="mt-2 text-gray-800">Заморожено до:
-        <%= current_user.unfreeze_at.present? ? current_user.unfreeze_at.strftime("%d-%m-%Y %H:%M") : "Бессрочно" %>
+      <h2 class="text-xl font-bold text-red-500"><%= t 'layouts.is_frozen.title' %></h2>
+      <p class="mt-4 text-gray-800"><%= t 'layouts.is_frozen.reason' %> <%= current_user.frozen_reason %></p>
+      <p class="mt-2 text-gray-800"><%= t 'layouts.is_frozen.frozen_at' %> <%= current_user.frozen_at.strftime("%d-%m-%Y %H:%M") %></p>
+      <p class="mt-2 text-gray-800"><%= t 'layouts.is_frozen.frozen_until' %>
+        <%= current_user.unfreeze_at.present? ? current_user.unfreeze_at.strftime("%d-%m-%Y %H:%M") : t('layouts.is_frozen.indefinitely') %>
       </p>
-      <p class="mt-4 text-gray-600">Если у вас есть вопросы, свяжитесь с нами по адресу: <a href="mailto:jammer.website@internet.ru" class="text-blue-500">jammer.website@internet.ru</a></p>
+      <p class="mt-4 text-gray-600"><%= t 'layouts.is_frozen.contact' %> <a href="mailto:jammer.website@internet.ru" class="text-blue-500">jammer.website@internet.ru</a></p>
 
       <div class="mt-6 flex justify-end">
-        <%= button_to "Выйти", logout_path, method: :delete,
+        <%= button_to t('buttons.sign_out'), logout_path, method: :delete,
                       class:"bg-gray-300 text-black py-2 px-4 rounded hover:bg-gray-400" %>
       </div>
     </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,7 +35,7 @@
             <div class="flex h-4 shrink-0 items-center"></div>
             <div class="logo">
               <%= link_to root_path do %>
-                <%= image_tag 'whitewithoutwall.png', alt: 'Логотип', width: '100', height: 'auto' %>
+                <%= image_tag 'whitewithoutwall.png', alt: t('layouts.application.logo_alt'), width: '100', height: 'auto' %>
               <% end %>
             </div>
             <nav class="flex flex-1 flex-col">
@@ -123,7 +123,7 @@
                               <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 6a7.5 7.5 0 107.5 7.5h-7.5V6z" />
                               <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 10.5H21A7.5 7.5 0 0013.5 3v7.5z" />
                             </svg>
-                            Панель администратора
+                            <%= t 'layouts.application.admin_panel' %>
                           </a>
                         </li>
                       <% end %>
@@ -138,7 +138,7 @@
                               <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 6a7.5 7.5 0 107.5 7.5h-7.5V6z" />
                               <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 10.5H21A7.5 7.5 0 0013.5 3v7.5z" />
                             </svg>
-                            Панель модератора
+                            <%= t 'layouts.application.moderator_panel' %>
                           </a>
                         </li>
                       <% end %>
@@ -194,7 +194,7 @@
                      text-gray-400 hover:bg-gray-800 cursor-pointer">
                       <span class="flex h-6 w-6 shrink-0 items-center justify-center rounded-lg border
                        border-gray-700 bg-gray-800 text-[0.625rem] font-medium text-gray-400
-                        group-hover:text-white">П</span>
+                        group-hover:text-white"><%= t "layouts.application.team_initial" %></span>
                         <span class="truncate">
                           <%= t 'layouts.left-menu.plug' %>
                         </span>
@@ -205,7 +205,7 @@
                      text-gray-400 hover:bg-gray-800 cursor-pointer">
                       <span class="flex h-6 w-6 shrink-0 items-center justify-center rounded-lg border
                        border-gray-700 bg-gray-800 text-[0.625rem] font-medium text-gray-400
-                       group-hover:text-white">П</span>
+                       group-hover:text-white"><%= t "layouts.application.team_initial" %></span>
                         <span class="truncate">
                           <%= t 'layouts.left-menu.plug' %>
                         </span>
@@ -216,7 +216,7 @@
                      text-gray-400 hover:bg-gray-800">
                       <span class="flex h-6 w-6 shrink-0 items-center justify-center rounded-lg border
                        border-gray-700 bg-gray-800 text-[0.625rem] font-medium text-gray-400
-                        group-hover:text-white">П</span>
+                        group-hover:text-white"><%= t "layouts.application.team_initial" %></span>
                         <span class="truncate">
                           <%= t 'layouts.left-menu.plug' %>
                         </span>
@@ -252,7 +252,7 @@
         <div class="flex h-4 shrink-0 items-center"></div>
         <div class="logo">
           <%= link_to root_path do %>
-            <%= image_tag 'whitewithoutwall.png', alt: 'Логотип', width: '100', height: 'auto' %>
+            <%= image_tag 'whitewithoutwall.png', alt: t('layouts.application.logo_alt'), width: '100', height: 'auto' %>
           <% end %>
         </div>
         <nav class="flex flex-1 flex-col">
@@ -340,7 +340,7 @@
                           <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 6a7.5 7.5 0 107.5 7.5h-7.5V6z" />
                           <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 10.5H21A7.5 7.5 0 0013.5 3v7.5z" />
                         </svg>
-                        Панель администратора
+                        <%= t 'layouts.application.admin_panel' %>
                       </a>
                     </li>
                   <% end %>
@@ -355,7 +355,7 @@
                           <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 6a7.5 7.5 0 107.5 7.5h-7.5V6z" />
                           <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 10.5H21A7.5 7.5 0 0013.5 3v7.5z" />
                         </svg>
-                        Панель модератора
+                        <%= t 'layouts.application.moderator_panel' %>
                       </a>
                     </li>
                   <% end %>
@@ -410,7 +410,7 @@
                 text-gray-400 hover:bg-gray-800">
                   <span class="flex h-6 w-6 shrink-0 items-center justify-center rounded-lg border
                    border-gray-700 bg-gray-800 text-[0.625rem] font-medium text-gray-400
-                    group-hover:text-white">П</span>
+                    group-hover:text-white"><%= t "layouts.application.team_initial" %></span>
                     <span class="truncate">
                       <%= t 'layouts.left-menu.plug' %>
                     </span>
@@ -421,7 +421,7 @@
                 text-gray-400 hover:bg-gray-800">
                   <span class="flex h-6 w-6 shrink-0 items-center justify-center rounded-lg border
                    border-gray-700 bg-gray-800 text-[0.625rem] font-medium text-gray-400
-                    group-hover:text-white">П</span>
+                    group-hover:text-white"><%= t "layouts.application.team_initial" %></span>
                     <span class="truncate">
                       <%= t 'layouts.left-menu.plug' %>
                     </span>
@@ -432,7 +432,7 @@
                  text-gray-400 hover:bg-gray-800">
                   <span class="flex h-6 w-6 shrink-0 items-center justify-center rounded-lg border
                    border-gray-700 bg-gray-800 text-[0.625rem] font-medium text-gray-400
-                   group-hover:text-white">П</span>
+                   group-hover:text-white"><%= t "layouts.application.team_initial" %></span>
                     <span class="truncate">
                       <%= t 'layouts.left-menu.plug' %>
                     </span>

--- a/app/views/moderator/games/_form.html.erb
+++ b/app/views/moderator/games/_form.html.erb
@@ -1,6 +1,6 @@
 <div class="p-6" data-controller="settings">
   <div class="mt-4">
-    <%= link_to 'Назад', request.referer && URI(request.referer).path != request.fullpath ? URI(request.referer).path : moderator_games_path, class: 'bg-gray-300 text-gray-800 py-2 px-4 rounded hover:bg-gray-400' %>
+    <%= link_to t('admin.shared.back'), request.referer && URI(request.referer).path != request.fullpath ? URI(request.referer).path : moderator_games_path, class: 'bg-gray-300 text-gray-800 py-2 px-4 rounded hover:bg-gray-400' %>
   </div>
 
   <div>
@@ -31,15 +31,15 @@
                 <%= f.label :status, class: 'block text-sm font-medium text-gray-700' %>
               </div>
               <div class="w-3/4">
-                <p class="text-sm">0 - Модерация; 1 - Одобрено; 2 - Отклонено</p>
+                <p class="text-sm"><%= t('admin.shared.status_hint') %></p>
                 <%= f.select :status, options_for_select([['0', 0], ['1', 1], ['2', 2]], f.object.status),
                              { target: 'status' },
                              class: 'mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50',
                              id: "game_status",
                              data: { action: 'change->status#updateReasonField', status_target: 'status' } %>
                 <div data-status-target="reasonField" style="<%= f.object.status == 2 ? '' : 'display: none;' %>">
-                  <%= f.label :reason, "Причина отклонения", class: 'block text-sm font-medium text-gray-700 mt-2' %>
-                  <%= f.select :reason, [['Непристойный контент', 'Непристойный контент'], ['Реклама', 'Реклама'], ['Плагиат', 'Плагиат']],
+                  <%= f.label :reason, t('admin.shared.rejection_reason'), class: 'block text-sm font-medium text-gray-700 mt-2' %>
+                  <%= f.select :reason, [[t('admin.shared.rejection_reasons.indecent_content'), 'Непристойный контент'], [t('admin.shared.rejection_reasons.advertising'), 'Реклама'], [t('admin.shared.rejection_reasons.plagiarism'), 'Плагиат']],
                                { include_blank: true },
                                class: 'mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50' %>
                 </div>
@@ -49,11 +49,11 @@
 
           <div class="flex items-center">
             <div class="w-1/4">
-              <%= f.label :cover, "Обложка", class: "block text-sm font-medium text-gray-700" %>
+              <%= f.label :cover, t('.cover'), class: "block text-sm font-medium text-gray-700" %>
             </div>
             <div class="w-3/4">
               <label class="block text-sm font-medium text-gray-700 mb-2" for="game_cover">
-                Обложка
+                <%= t('.cover') %>
               </label>
               <%= f.file_field :cover, class: "mt-1 block w-full text-gray-500 file:py-2 file:px-4 file:border file:border-gray-300 file:rounded-md file:bg-gray-100 file:text-sm file:font-medium hover:file:bg-gray-200 focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50" %>
 
@@ -73,20 +73,20 @@
 
           <div class="flex items-center">
             <div class="w-1/4">
-              <%= f.label :game_file, "Файл игры",
+              <%= f.label :game_file, t('.game_file'),
                              class: "block text-sm font-medium text-gray-700" %>
             </div>
             <div class="w-3/4">
               <label class="block text-sm font-medium text-gray-700 mb-2" for="game_game_file">
-                Файл игры
+                <%= t('.game_file') %>
               </label>
               <%= f.file_field :game_file, accept: ".zip,.rar,.7z",
                                class: "mt-1 block w-full text-gray-500 file:py-2 file:px-4 file:border file:border-gray-300 file:rounded-md file:bg-gray-100 file:text-sm file:font-medium hover:file:bg-gray-200 focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50" %>
 
               <% if game.game_file.attached? %>
                 <p class="mt-2 text-sm text-gray-500">
-                  Текущий файл:
-                  <%= link_to "Скачать архив", url_for(@game.game_file),
+                  <%= t('.current_file') %>
+                  <%= link_to t('.download_archive'), url_for(@game.game_file),
                               download: true,
                               class: "text-indigo-600 hover:text-indigo-900 font-medium underline" %>
                 </p>
@@ -96,7 +96,7 @@
 
           <div class="flex items-center">
             <div class="w-1/4">
-              <%= f.label :tags, "Теги", class: "block text-sm font-medium text-gray-700" %>
+              <%= f.label :tags, t('admin.shared.tags'), class: "block text-sm font-medium text-gray-700" %>
             </div>
             <div class="w-3/4">
               <div class="mt-1">
@@ -114,7 +114,7 @@
             <div class="w-1/4"></div>
             <div class="w-3/4">
               <div class="mt-6 flex items-center space-x-2">
-                <%= f.submit 'Сохранить', class: 'bg-green-500 text-white py-2 px-4 rounded hover:bg-green-600' %>
+                <%= f.submit t('admin.shared.save'), class: 'bg-green-500 text-white py-2 px-4 rounded hover:bg-green-600' %>
               </div>
             </div>
           </div>

--- a/app/views/moderator/games/_game.html.erb
+++ b/app/views/moderator/games/_game.html.erb
@@ -8,7 +8,7 @@
           <%= truncate(game.author.name, length: 15) %>
         </a>
       <% else %>
-        <span>Автор неизвестен</span>
+        <span><%= t('admin.shared.author_unknown') %></span>
       <% end %>
     </td>
     <td class="py-3 px-6 hover:underline">
@@ -17,8 +17,8 @@
     <td class="py-3 px-10"><%= game.status %></td>
     <td class="py-3 px-6"><%= game.created_at.strftime("%Y-%m-%d %H:%M") %></td>
     <td class="py-3 px-6 flex flex-col sm:flex-row space-y-2 sm:space-y-0 sm:space-x-2">
-      <%= link_to 'Edit', edit_moderator_game_path(game), class: 'bg-blue-500 text-white py-1 px-3 rounded hover:bg-blue-600' %>
-      <%= link_to 'Delete', moderator_game_path(game), class: 'bg-red-500 text-white py-1 px-3 rounded hover:bg-red-600', data: { turbo_method: :delete, turbo_confirm: 'Вы уверены?' } %>
+      <%= link_to t('admin.shared.edit'), edit_moderator_game_path(game), class: 'bg-blue-500 text-white py-1 px-3 rounded hover:bg-blue-600' %>
+      <%= link_to t('admin.shared.delete'), moderator_game_path(game), class: 'bg-red-500 text-white py-1 px-3 rounded hover:bg-red-600', data: { turbo_method: :delete, turbo_confirm: t('admin.shared.confirm') } %>
     </td>
   </tr>
 <% end %>

--- a/app/views/moderator/games/index.html.erb
+++ b/app/views/moderator/games/index.html.erb
@@ -3,12 +3,12 @@
     <%= form_with url: moderator_games_path, method: :get, class: "pb-4", local: true do |form| %>
       <div class="flex flex-col md:flex-row items-center space-y-2 md:space-y-0 md:space-x-4 w-full">
         <div class="flex items-center w-full md:w-auto">
-          <%= form.label :query, "Поиск игр", class: 'block font-semibold text-gray-700 mr-2' %>
+          <%= form.label :query, t('.search_label'), class: 'block font-semibold text-gray-700 mr-2' %>
           <%= form.text_field :query, value: params[:query], placeholder: '', class: 'border border-gray-300 rounded-lg p-2 text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent w-full' %>
         </div>
         <div class="flex items-center space-x-2 mt-2 md:mt-0">
-          <%= form.submit 'Поиск', class: 'bg-blue-500 text-white font-semibold py-2 px-4 rounded-lg hover:bg-blue-600 transition duration-150 ease-in-out shadow' %>
-          <%= link_to 'Сбросить', moderator_games_path, class: 'text-gray-500 hover:text-gray-700 font-semibold' %>
+          <%= form.submit t('admin.shared.search'), class: 'bg-blue-500 text-white font-semibold py-2 px-4 rounded-lg hover:bg-blue-600 transition duration-150 ease-in-out shadow' %>
+          <%= link_to t('admin.shared.reset'), moderator_games_path, class: 'text-gray-500 hover:text-gray-700 font-semibold' %>
         </div>
       </div>
     <% end %>
@@ -49,6 +49,6 @@
     </div>
     <%= render partial: 'helpers/pagy' %>
   <% else %>
-    <p class="text-gray-500 m-8">Игры не найдены по запросу "<%= params[:query] %>".</p>
+    <p class="text-gray-500 m-8"><%= t('.not_found', query: params[:query]) %></p>
   <% end %>
 </div>

--- a/app/views/moderator/jams/_form.html.erb
+++ b/app/views/moderator/jams/_form.html.erb
@@ -1,6 +1,6 @@
 <div class="p-6" data-controller="settings">
   <div class="mt-4">
-    <%= link_to 'Назад', request.referer && URI(request.referer).path != request.fullpath ? URI(request.referer).path : moderator_jams_path, class: 'bg-gray-300 text-gray-800 py-2 px-4 rounded hover:bg-gray-400' %>
+    <%= link_to t('moderator.shared.back'), request.referer && URI(request.referer).path != request.fullpath ? URI(request.referer).path : moderator_jams_path, class: 'bg-gray-300 text-gray-800 py-2 px-4 rounded hover:bg-gray-400' %>
   </div>
 
   <div>
@@ -27,7 +27,7 @@
 
           <div class="flex items-center">
             <div class="w-1/4">
-              <%= f.label :start_date, "Дата начала", class: "block text-sm font-medium text-gray-700" %>
+              <%= f.label :start_date, t('.start_date'), class: "block text-sm font-medium text-gray-700" %>
             </div>
             <div class="w-3/4">
               <%= f.date_field :start_date, required: true,
@@ -39,7 +39,7 @@
 
           <div class="flex items-center">
             <div class="w-1/4">
-              <%= f.label :deadline, "Дедлайн сдачи работ", class: "block text-sm font-medium text-gray-700" %>
+              <%= f.label :deadline, t('.deadline'), class: "block text-sm font-medium text-gray-700" %>
             </div>
             <div class="w-3/4">
               <%= f.date_field :deadline, required: true,
@@ -51,7 +51,7 @@
 
           <div class="flex items-center">
             <div class="w-1/4">
-              <%= f.label :end_date, "Дата окончания джема", class: "block text-sm font-medium text-gray-700" %>
+              <%= f.label :end_date, t('.end_date'), class: "block text-sm font-medium text-gray-700" %>
             </div>
             <div class="w-3/4">
               <%= f.date_field :end_date, required: true,
@@ -67,15 +67,15 @@
                 <%= f.label :status, class: 'block text-sm font-medium text-gray-700' %>
               </div>
               <div class="w-3/4">
-                <p class="text-sm">0 - Модерация; 1 - Одобрено; 2 - Отклонено</p>
+                <p class="text-sm"><%= t('moderator.shared.status_hint') %></p>
                 <%= f.select :status, options_for_select([['0', 0], ['1', 1], ['2', 2]], f.object.status),
                              { target: 'status' },
                              class: 'mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50',
                              id: "game_status",
                              data: { action: 'change->status#updateReasonField', status_target: 'status' } %>
                 <div data-status-target="reasonField" style="<%= f.object.status == 2 ? '' : 'display: none;' %>">
-                  <%= f.label :reason, "Причина отклонения", class: 'block text-sm font-medium text-gray-700 mt-2' %>
-                  <%= f.select :reason, [['Непристойный контент', 'Непристойный контент'], ['Реклама', 'Реклама'], ['Плагиат', 'Плагиат']],
+                  <%= f.label :reason, t('moderator.shared.rejection_reason'), class: 'block text-sm font-medium text-gray-700 mt-2' %>
+                  <%= f.select :reason, [[t('moderator.shared.rejection_reasons.indecent_content'), 'Непристойный контент'], [t('moderator.shared.rejection_reasons.advertising'), 'Реклама'], [t('moderator.shared.rejection_reasons.plagiarism'), 'Плагиат']],
                                { include_blank: true },
                                class: 'mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50' %>
                 </div>
@@ -85,11 +85,11 @@
 
           <div class="flex items-center">
             <div class="w-1/4">
-              <%= f.label :cover, "Обложка", class: "block text-sm font-medium text-gray-700" %>
+              <%= f.label :cover, t('.cover'), class: "block text-sm font-medium text-gray-700" %>
             </div>
             <div class="w-3/4">
               <label class="block text-sm font-medium text-gray-700 mb-2" for="game_cover">
-                Обложка
+                <%= t('.cover') %>
               </label>
               <%= f.file_field :cover, class: "mt-1 block w-full text-gray-500 file:py-2 file:px-4 file:border file:border-gray-300 file:rounded-md file:bg-gray-100 file:text-sm file:font-medium hover:file:bg-gray-200 focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50" %>
 
@@ -109,11 +109,11 @@
 
           <div class="flex items-center">
             <div class="w-1/4">
-              <%= f.label :logo, "Логотип", class: "block text-sm font-medium text-gray-700" %>
+              <%= f.label :logo, t('.logo'), class: "block text-sm font-medium text-gray-700" %>
             </div>
             <div class="w-3/4">
               <label class="block text-sm font-medium text-gray-700 mb-2" for="game_cover">
-                Логотип
+                <%= t('.logo') %>
               </label>
               <%= f.file_field :logo, class: "mt-1 block w-full text-gray-500 file:py-2 file:px-4 file:border file:border-gray-300 file:rounded-md file:bg-gray-100 file:text-sm file:font-medium hover:file:bg-gray-200 focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50" %>
 
@@ -133,7 +133,7 @@
 
           <div class="flex items-center">
             <div class="w-1/4">
-              <%= f.label :tags, "Теги", class: "block text-sm font-medium text-gray-700" %>
+              <%= f.label :tags, t('moderator.shared.tags'), class: "block text-sm font-medium text-gray-700" %>
             </div>
             <div class="w-3/4">
               <div class="mt-1">
@@ -151,7 +151,7 @@
             <div class="w-1/4"></div>
             <div class="w-3/4">
               <div class="mt-6 flex items-center space-x-2">
-                <%= f.submit 'Сохранить', class: 'bg-green-500 text-white py-2 px-4 rounded hover:bg-green-600' %>
+                <%= f.submit t('moderator.shared.save'), class: 'bg-green-500 text-white py-2 px-4 rounded hover:bg-green-600' %>
               </div>
             </div>
           </div>

--- a/app/views/moderator/jams/_jam.html.erb
+++ b/app/views/moderator/jams/_jam.html.erb
@@ -8,7 +8,7 @@
           <%= truncate(jam.author.name, length: 15) %>
         </a>
       <% else %>
-        <span>Автор неизвестен</span>
+        <span><%= t('moderator.shared.author_unknown') %></span>
       <% end %>
     </td>
     <td class="py-3 px-6 hover:underline">
@@ -17,8 +17,8 @@
     <td class="py-3 px-10"><%= jam.status %></td>
     <td class="py-3 px-6"><%= jam.created_at.strftime("%Y-%m-%d %H:%M") %></td>
     <td class="py-3 px-6 flex flex-col sm:flex-row space-y-2 sm:space-y-0 sm:space-x-2">
-      <%= link_to 'Edit', edit_moderator_jam_path(jam), class: 'bg-blue-500 text-white py-1 px-3 rounded hover:bg-blue-600' %>
-      <%= link_to 'Delete', moderator_jam_path(jam), class: 'bg-red-500 text-white py-1 px-3 rounded hover:bg-red-600', data: { turbo_method: :delete, turbo_confirm: 'Вы уверены?' } %>
+      <%= link_to t('moderator.shared.edit'), edit_moderator_jam_path(jam), class: 'bg-blue-500 text-white py-1 px-3 rounded hover:bg-blue-600' %>
+      <%= link_to t('moderator.shared.delete'), moderator_jam_path(jam), class: 'bg-red-500 text-white py-1 px-3 rounded hover:bg-red-600', data: { turbo_method: :delete, turbo_confirm: t('moderator.shared.confirm') } %>
     </td>
   </tr>
 <% end %>

--- a/app/views/moderator/jams/index.html.erb
+++ b/app/views/moderator/jams/index.html.erb
@@ -3,12 +3,12 @@
     <%= form_with url: moderator_jams_path, method: :get, class: "pb-4", local: true do |form| %>
       <div class="flex flex-col md:flex-row items-center space-y-2 md:space-y-0 md:space-x-4 w-full">
         <div class="flex items-center w-full md:w-auto">
-          <%= form.label :query, "Поиск джемов", class: 'block font-semibold text-gray-700 mr-2' %>
+          <%= form.label :query, t('.search_label'), class: 'block font-semibold text-gray-700 mr-2' %>
           <%= form.text_field :query, value: params[:query], placeholder: '', class: 'border border-gray-300 rounded-lg p-2 text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent w-full' %>
         </div>
         <div class="flex items-center space-x-2 mt-2 md:mt-0">
-          <%= form.submit 'Поиск', class: 'bg-blue-500 text-white font-semibold py-2 px-4 rounded-lg hover:bg-blue-600 transition duration-150 ease-in-out shadow' %>
-          <%= link_to 'Сбросить', moderator_jams_path, class: 'text-gray-500 hover:text-gray-700 font-semibold' %>
+          <%= form.submit t('moderator.shared.search'), class: 'bg-blue-500 text-white font-semibold py-2 px-4 rounded-lg hover:bg-blue-600 transition duration-150 ease-in-out shadow' %>
+          <%= link_to t('moderator.shared.reset'), moderator_jams_path, class: 'text-gray-500 hover:text-gray-700 font-semibold' %>
         </div>
       </div>
     <% end %>
@@ -49,6 +49,6 @@
     </div>
     <%= render partial: 'helpers/pagy' %>
   <% else %>
-    <p class="text-gray-500 m-8">Джемы не найдены по запросу "<%= params[:query] %>".</p>
+    <p class="text-gray-500 m-8"><%= t('.not_found', query: params[:query]) %></p>
   <% end %>
 </div>

--- a/app/views/moderators/index.html.erb
+++ b/app/views/moderators/index.html.erb
@@ -1,21 +1,21 @@
 <div class="p-16">
-  <h1 class="text-3xl font-bold mb-6">Панель модератора</h1>
+  <h1 class="text-3xl font-bold mb-6"><%= t('.title') %></h1>
 
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
     <div class="bg-white shadow-md rounded-lg p-6 flex flex-col justify-between h-full">
       <div>
-        <h2 class="text-xl font-semibold mb-2">Игры</h2>
-        <p class="text-gray-600 mb-4">Редактирование игр</p>
+        <h2 class="text-xl font-semibold mb-2"><%= t('.games.title') %></h2>
+        <p class="text-gray-600 mb-4"><%= t('.games.description') %></p>
       </div>
-      <%= link_to 'Перейти', moderator_games_path, class: 'bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600 transition mt-4' %>
+      <%= link_to t('.go'), moderator_games_path, class: 'bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600 transition mt-4' %>
     </div>
 
     <div class="bg-white shadow-md rounded-lg p-6 flex flex-col justify-between h-full">
       <div>
-        <h2 class="text-xl font-semibold mb-2">Джемы</h2>
-        <p class="text-gray-600 mb-4">Редактирование джемов</p>
+        <h2 class="text-xl font-semibold mb-2"><%= t('.jams.title') %></h2>
+        <p class="text-gray-600 mb-4"><%= t('.jams.description') %></p>
       </div>
-      <%= link_to 'Перейти', moderator_jams_path, class: 'bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600 transition mt-4' %>
+      <%= link_to t('.go'), moderator_jams_path, class: 'bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600 transition mt-4' %>
     </div>
   </div>
 </div>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -104,7 +104,7 @@
 
               <% if current_user && contributor.user_id == current_user.id && contributor.status == "pending" %>
                 <div class="mt-2">
-                  <%= button_to "Принять приглашение",
+                  <%= button_to t('.accept_jury_invite'),
                                 accept_contributor_invite_jam_path(jam, contributor_id: contributor.id),
                                 method: :patch,
                                 class: "rounded bg-indigo-600 px-3 py-1 text-white hover:bg-indigo-700" %>

--- a/app/views/password_reset_mailer/reset_email.html.erb
+++ b/app/views/password_reset_mailer/reset_email.html.erb
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="ru">
+<html lang="<%= I18n.locale %>">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Сброс пароля</title>
+  <title><%= t('mailers.password_reset.title') %></title>
   <style>
       body {
           font-family: Arial, sans-serif;
@@ -44,13 +44,13 @@
 <body>
 
 <div class="container">
-  <h1>Сброс пароля</h1>
-  <p>Кто-то запросил сброс пароля для вашей учетной записи.</p>
-  <p>Если это были вы, нажмите на кнопку ниже, чтобы установить новый пароль:</p>
+  <h1><%= t('mailers.password_reset.title') %></h1>
+  <p><%= t('mailers.password_reset.body_intro') %></p>
+  <p><%= t('mailers.password_reset.body_action') %></p>
   <p>
-    <%= link_to 'Сбросить мой пароль', edit_password_reset_url(user: { password_reset_token: @user.password_reset_token, email: @user.email }).gsub("&amp;", "&").html_safe, class: 'button', target: '_blank' %>
+    <%= link_to t('mailers.password_reset.button'), edit_password_reset_url(user: { password_reset_token: @user.password_reset_token, email: @user.email }).gsub("&amp;", "&").html_safe, class: 'button', target: '_blank' %>
   </p>
-  <p>Если вы не запрашивали сброс пароля, просто проигнорируйте это сообщение.</p>
+  <p><%= t('mailers.password_reset.body_ignore') %></p>
 </div>
 
 </body>

--- a/app/views/password_reset_mailer/reset_email.text.erb
+++ b/app/views/password_reset_mailer/reset_email.text.erb
@@ -1,8 +1,8 @@
-Сброс пароля
-Кто-то запросил сброс пароля для вашей учетной записи.
-Если это были вы, нажмите на кнопку ниже, чтобы установить новый пароль:
+<%= t('mailers.password_reset.title') %>
+<%= t('mailers.password_reset.body_intro') %>
+<%= t('mailers.password_reset.body_action') %>
 
 <%= url_for edit_password_reset_url(user: { password_reset_token: @user.password_reset_token,
                                             email: @user.email }).gsub('&amp;', '&') %>
 
-Если вы не запрашивали сброс пароля, просто проигнорируйте это сообщение.
+<%= t('mailers.password_reset.body_ignore') %>

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,27 +1,27 @@
 <div class="flex min-h-full flex-col justify-center py-12 sm:px-6 lg:px-8">
   <div class="mt-10 sm:mx-auto sm:w-full sm:max-w-[480px]">
     <%= form_with model: @user, url: password_reset_path, method: :patch, class: 'max-w-md mx-auto p-8 bg-white rounded-lg shadow-lg' do |f| %>
-  <h2 class="text-2xl font-bold text-center mb-6">Сброс пароля</h2>
+  <h2 class="text-2xl font-bold text-center mb-6"><%= t '.title' %></h2>
 
   <%= f.hidden_field :password_reset_token, value: @user.password_reset_token %>
   <%= f.hidden_field :email, value: @user.email %>
 
   <div class="mb-4">
-    <%= f.label :password, class: 'block text-gray-700 text-sm font-semibold mb-1' %>
+    <%= f.label :password, t('.password_label'), class: 'block text-gray-700 text-sm font-semibold mb-1' %>
     <%= f.password_field :password, class: 'shadow appearance-none border border-gray-300 rounded w-full py-3 px-4 text-gray-700 leading-tight focus:outline-none focus:ring focus:ring-blue-300 focus:border-blue-500' %>
   </div>
 
   <div class="mb-4">
-    <%= f.label :password_confirmation, class: 'block text-gray-700 text-sm font-semibold mb-1' %>
+    <%= f.label :password_confirmation, t('.password_confirmation_label'), class: 'block text-gray-700 text-sm font-semibold mb-1' %>
     <%= f.password_field :password_confirmation, class: 'shadow appearance-none border border-gray-300 rounded w-full py-3 px-4 text-gray-700 leading-tight focus:outline-none focus:ring focus:ring-blue-300 focus:border-blue-500' %>
   </div>
 
   <div class="flex items-center justify-between">
-    <%= f.submit 'Сохранить', class: 'w-full bg-blue-500 hover:bg-blue-700 text-white font-semibold py-2 rounded focus:outline-none focus:shadow-outline' %>
+    <%= f.submit t('buttons.save'), class: 'w-full bg-blue-500 hover:bg-blue-700 text-white font-semibold py-2 rounded focus:outline-none focus:shadow-outline' %>
   </div>
 
   <div class="mt-4 text-center">
-    <p class="text-sm text-gray-600">Вернуться ко <%= link_to 'входу', login_path, class: 'text-blue-500 hover:underline' %></p>
+    <p class="text-sm text-gray-600"><%= t '.back' %> <%= link_to t('.login'), login_path, class: 'text-blue-500 hover:underline' %></p>
   </div>
 <% end %>
   </div>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,16 +1,16 @@
 <div class="flex min-h-full flex-col justify-center py-12 sm:px-6 lg:px-8">
   <div class="mt-10 sm:mx-auto sm:w-full sm:max-w-[480px]">
-    <h1 class="mb-6 text-2xl font-semibold">Сброс пароля</h1>
+    <h1 class="mb-6 text-2xl font-semibold"><%= t '.title' %></h1>
     <%= form_with url: password_reset_path, class: 'space-y-4' do |f| %>
   <div class="flex flex-col">
     <label for="email" class="mb-2 font-medium text-gray-700">
-      <%= f.label :email, 'Введите ваш email' %>
+      <%= f.label :email, t('.email_label') %>
     </label>
     <%= f.email_field :email, value: params[:email], required: true, class: 'p-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500' %>
   </div>
 
-  <%= f.submit 'Отправить', class: 'w-full px-4 py-2 text-white bg-blue-600 rounded-lg hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500' %>
-  <%= link_to 'Назад', request.referer && URI(request.referer).path != request.fullpath ? URI(request.referer).path : login_path, class: 'inline-block mt-4 px-4 py-2 text-blue-600 bg-gray-200 rounded-lg hover:bg-gray-300' %>
+  <%= f.submit t('.submit'), class: 'w-full px-4 py-2 text-white bg-blue-600 rounded-lg hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500' %>
+  <%= link_to t('.back'), request.referer && URI(request.referer).path != request.fullpath ? URI(request.referer).path : login_path, class: 'inline-block mt-4 px-4 py-2 text-blue-600 bg-gray-200 rounded-lg hover:bg-gray-300' %>
 <% end %>
   </div>
 </div>

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -68,7 +68,7 @@
                          id="current-background-img" src="<%= url_for(@user.background_image) %>"
                          alt="Current Background Image" class="mb-4 w-full h-auto object-cover rounded-md"/>
                   <% end %>
-                  <img data-background-image-target="previewImg" id="preview-img" src="#" alt="Предварительный просмотр изображения" class="mt-4 hidden w-full h-auto object-cover rounded-md">
+                  <img data-background-image-target="previewImg" id="preview-img" src="#" alt="<%= t '.account.image.preview_alt' %>" class="mt-4 hidden w-full h-auto object-cover rounded-md">
                   <input data-background-image-target="input" type="file" name="user[background_image]"
                          id="background_image"
                          class="absolute inset-0 opacity-0 cursor-pointer" accept="image/*">
@@ -638,18 +638,21 @@
                         <p class="text-sm text-gray-500"><%= t 'settings.index.security.active_sessions.browser' %>
                           Unknown</p>
                       <% end %>
-                      <p class="text-sm text-gray-500"><%= t 'settings.index.security.active_sessions.browserid' %> <%= session.created_at %></p>
+                      <p class="text-sm text-gray-500"><%= t 'settings.index.security.active_sessions.created' %> <%= session.created_at %></p>
                     </div>
                   </li>
                 <% end %>
               </div>
               <li class="py-4">
-                <button id="toggle-more-sessions" class="text-indigo-600 hover:underline">View all sessions</button>
+                <button id="toggle-more-sessions"
+                        class="text-indigo-600 hover:underline"
+                        data-show-text="<%= t '.security.active_sessions.view_all' %>"
+                        data-hide-text="<%= t '.security.active_sessions.hide_all' %>"><%= t '.security.active_sessions.view_all' %></button>
               </li>
             <% end %>
           </ul>
         <% else %>
-          <p class="text-sm text-gray-500">No active sessions found.</p>
+          <p class="text-sm text-gray-500"><%= t '.security.active_sessions.none' %></p>
         <% end %>
       </div>
     </div>
@@ -659,10 +662,10 @@
             const moreSessions = document.getElementById('more-sessions');
             if (moreSessions.classList.contains('hidden')) {
                 moreSessions.classList.remove('hidden');
-                this.textContent = 'Hide all sessions';
+                this.textContent = this.dataset.hideText;
             } else {
                 moreSessions.classList.add('hidden');
-                this.textContent = 'View all sessions';
+                this.textContent = this.dataset.showText;
             }
         });
     </script>
@@ -670,7 +673,7 @@
     <div data-controller="modal">
       <div class="grid max-w-7xl grid-cols-1 gap-x-8 gap-y-10 px-4 py-16 sm:px-6 md:grid-cols-3 lg:px-8">
         <div>
-          <h2 class="text-base font-semibold leading-7 text-white">Delete account</h2>
+          <h2 class="text-base font-semibold leading-7 text-white"><%= t '.security.delete.title' %></h2>
           <p class="mt-1 text-sm leading-6 text-gray-400">
             <%= t '.security.delete.hint' %>
           </p>
@@ -718,8 +721,8 @@
   <div id="billing-section" class="section divide-y set-menuitem hidden">
     <div class="grid max-w-7xl grid-cols-1 gap-x-8 gap-y-10 px-4 py-16 sm:px-6 md:grid-cols-3 lg:px-8">
       <div>
-        <h2 class="text-base font-semibold leading-7 text-white">Какое-то поле (billing)</h2>
-        <p class="mt-1 text-sm leading-6 text-gray-400">Какое-то поле</p>
+        <h2 class="text-base font-semibold leading-7 text-white"><%= t '.placeholders.billing_title' %></h2>
+        <p class="mt-1 text-sm leading-6 text-gray-400"><%= t '.placeholders.field' %></p>
       </div>
 
       <%= form_for @user, url: user_path(@user), method: :put, html: { class: 'md:col-span-2' } do |f| %>
@@ -727,7 +730,7 @@
 
           <% 16.times do %>
             <div class="field col-span-full">
-              <label class="block text-sm font-medium text-white">Какое-то поле (billing)</label>
+              <label class="block text-sm font-medium text-white"><%= t '.placeholders.billing_title' %></label>
             </div>
           <% end %>
         </div>
@@ -738,8 +741,8 @@
   <div id="teams-section" class="section divide-y set-menuitem hidden">
     <div class="grid max-w-7xl grid-cols-1 gap-x-8 gap-y-10 px-4 py-16 sm:px-6 md:grid-cols-3 lg:px-8">
       <div>
-        <h2 class="text-base font-semibold leading-7 text-white">Какое-то поле (teams)</h2>
-        <p class="mt-1 text-sm leading-6 text-gray-400">Какое-то поле</p>
+        <h2 class="text-base font-semibold leading-7 text-white"><%= t '.placeholders.teams_title' %></h2>
+        <p class="mt-1 text-sm leading-6 text-gray-400"><%= t '.placeholders.field' %></p>
       </div>
 
       <%= form_for @user, url: user_path(@user), method: :put, html: { class: 'md:col-span-2' } do |f| %>
@@ -747,7 +750,7 @@
 
           <% 16.times do %>
             <div class="field col-span-full">
-              <label class="block text-sm font-medium text-white">Какое-то поле (teams)</label>
+              <label class="block text-sm font-medium text-white"><%= t '.placeholders.teams_title' %></label>
             </div>
           <% end %>
         </div>
@@ -758,8 +761,8 @@
   <div id="integrations-section" class="section divide-y set-menuitem hidden">
     <div class="grid max-w-7xl grid-cols-1 gap-x-8 gap-y-10 px-4 py-16 sm:px-6 md:grid-cols-3 lg:px-8">
       <div>
-        <h2 class="text-base font-semibold leading-7 text-white">Какое-то поле (integrations)</h2>
-        <p class="mt-1 text-sm leading-6 text-gray-400">Какое-то поле</p>
+        <h2 class="text-base font-semibold leading-7 text-white"><%= t '.placeholders.integrations_title' %></h2>
+        <p class="mt-1 text-sm leading-6 text-gray-400"><%= t '.placeholders.field' %></p>
       </div>
 
       <%= form_for @user, url: user_path(@user), method: :put, html: { class: 'md:col-span-2' } do |f| %>
@@ -767,7 +770,7 @@
 
           <% 16.times do %>
             <div class="field col-span-full">
-              <label class="block text-sm font-medium text-white">Какое-то поле (integrations)</label>
+              <label class="block text-sm font-medium text-white"><%= t '.placeholders.integrations_title' %></label>
             </div>
           <% end %>
         </div>

--- a/app/views/users/_profile.html.erb
+++ b/app/views/users/_profile.html.erb
@@ -51,12 +51,12 @@
 
         <% if @user.is_frozen? %>
           <div class="alert alert-danger text-red-500">
-            <strong>Пользователь заморожен!</strong>
+            <strong><%= t '.user_frozen' %></strong>
             <br>
             <% if @user.unfreeze_at.present? %>
-              <span>Дата разморозки: <%= @user.unfreeze_at.strftime("%d-%m-%Y %H:%M") %></span>
+              <span><%= t '.unfreeze_at' %> <%= @user.unfreeze_at.strftime("%d-%m-%Y %H:%M") %></span>
             <% else %>
-              <span>Бессрочно</span>
+              <span><%= t '.frozen_indefinitely' %></span>
             <% end %>
           </div>
         <% end %>
@@ -87,15 +87,15 @@
                 <%= button_to t('buttons.add_friend'), user_friendships_path(@user), method: :post,
                               class: friend_btn_green %>
               <% elsif @friendship.status == 'pending' && @friendship.user == @current_user %>
-                <%= button_to "Cancel application", cancel_user_friendship_path(@user, @friendship),
+                <%= button_to t('.cancel_application'), cancel_user_friendship_path(@user, @friendship),
                               method: :delete, class: friend_btn_red %>
               <% elsif @friendship.status == 'accepted' %>
                 <%= button_to t("buttons.remove_friend"), user_friendship_path(@user, @friendship), method: :delete,
                               class: friend_btn_red %>
               <% elsif @friendship.status == 'pending' && @friendship.user != @current_user %>
-                <%= button_to "Accept application", user_friendship_path(@current_user, @friendship), method: :put,
+                <%= button_to t('.accept_application'), user_friendship_path(@current_user, @friendship), method: :put,
                               class: friend_btn_green %>
-                <%= button_to "Cancel application", cancel_user_friendship_path(@current_user, @friendship), method: :delete,
+                <%= button_to t('.cancel_application'), cancel_user_friendship_path(@current_user, @friendship), method: :delete,
                               class: friend_btn_red %>
               <% end %>
               <% if current_user %>
@@ -198,8 +198,11 @@
                     <% end %>
                   </ul>
                   <% if @user.games.count >= 8 %>
-                    <button id="toggle-button" class="mt-4 text-gray-400 hover:underline">
-                      Показать все игры
+                    <button id="toggle-button"
+                            class="mt-4 text-gray-400 hover:underline"
+                            data-show-text="<%= t '.show_all_games' %>"
+                            data-hide-text="<%= t '.hide_games' %>">
+                      <%= t '.show_all_games' %>
                     </button>
                   <% end %>
                 <% else %>
@@ -221,14 +224,14 @@
                             games.forEach(game => {
                                 game.classList.remove('hidden');
                             });
-                            this.innerText = 'Скрыть игры';
+                            this.innerText = this.dataset.hideText;
                         } else {
                             allGames.forEach((game, index) => {
                                 if (index >= 8) {
                                     game.classList.add('hidden');
                                 }
                             });
-                            this.innerText = 'Показать все игры';
+                            this.innerText = this.dataset.showText;
                         }
                     });
                 }
@@ -275,11 +278,11 @@
                                 <% label, classes =
                                      case role
                                      when :author
-                                       ["Автор", "bg-purple-100 text-purple-800"]
+                                       [t('.role_author'), "bg-purple-100 text-purple-800"]
                                      when :host
-                                       ["Хост", "bg-indigo-100 text-indigo-800"]
+                                       [t('.role_host'), "bg-indigo-100 text-indigo-800"]
                                      when :admin
-                                       ["Админ", "bg-amber-100 text-amber-800"]
+                                       [t('.role_admin'), "bg-amber-100 text-amber-800"]
                                      end
                                 %>
 
@@ -444,7 +447,7 @@
             data-last-active-at="<%= request.user.last_active_at.strftime('%Y-%m-%dT%H:%M:%S') %>"
             data-action="load->online#updateStatus"></span>
                             <% else %>
-                              <span class="text-sm text-gray-600">Offline</span>
+                              <span class="text-sm text-gray-600"><%= t '.offline' %></span>
                             <% end %>
                           </p>
                         <% end %>

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -2,7 +2,7 @@
 service: jammer
 
 # Name of the container image.
-image: fiitovec99/jammer
+image: <%= ENV["KAMAL_REGISTRY_USERNAME"] %>/jammer
 
 deploy_timeout: 90
 
@@ -29,7 +29,8 @@ proxy:
 registry:
   # Specify the registry server, if you're not using Docker Hub
   # server: registry.digitalocean.com / ghcr.io / ...
-  username: fiitovec99
+  username:
+    - KAMAL_REGISTRY_USERNAME
 
   # Always use an access token rather than real password (pulled from .kamal/secrets).
   password:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,6 +9,34 @@ en:
       game:
         name: "Name"
         description: "Description"
+    errors:
+      models:
+        game:
+          attributes:
+            cover:
+              blank: "Cover image is required"
+            game_file:
+              blank: "Game file is required"
+              wrong_format: "File must be in .zip, .rar or .7z format"
+              too_large: "Archive size must not exceed 100 MB"
+            tags:
+              too_long: "No more than %{count} tags can be selected"
+        jam:
+          attributes:
+            cover:
+              blank: "Cover image is required"
+            logo:
+              blank: "Logo image is required"
+            description:
+              blank: "Description is required"
+            tags:
+              too_long: "No more than %{count} tags can be selected"
+        report:
+          attributes:
+            reportable_id:
+              taken: "You have already filed a report on this entity"
+        jam_rating_setting:
+          both_disabled: "You cannot disable both jury and audience at the same time"
   buttons:
     save: "Save"
     change_avatar: "Change avatar"
@@ -17,6 +45,8 @@ en:
     profile: "Profile"
     sign_out: "Sign out"
     add_friend: "Add friend"
+    cancel: "Cancel"
+    close: "Close"
   search: "Search..."
   home:
     title: "Jammer service prototype"
@@ -40,6 +70,18 @@ en:
       requests: "Requests"
       settings: "Settings"
       plug: "Empty yet"
+    application:
+      logo_alt: "Logo"
+      admin_panel: "Admin panel"
+      moderator_panel: "Moderator panel"
+      team_initial: "T"
+    is_frozen:
+      title: "You are frozen!"
+      reason: "Reason:"
+      frozen_at: "Frozen at:"
+      frozen_until: "Frozen until:"
+      indefinitely: "Indefinitely"
+      contact: "If you have any questions, contact us at:"
   dashboard:
     index:
       title: "Dashboard"
@@ -49,6 +91,8 @@ en:
       jams_games_rating: "Average rating of your games in jams: "
       jams_reviews: "Your jams reviews: "
       no_comment: "No comment"
+      my_jams: "My jams"
+      no_jams: "You are not participating in or administrating any jam yet."
   games:
     create:
       success: "Game has been created successfully!"
@@ -67,6 +111,14 @@ en:
       checkbox: "Search with at least one of the selected tags"
       not_found: "Nothing found for the current request"
       no_author: "Author not found"
+      all_games: "All games"
+      my_games: "My games"
+      no_accepted: "You have no accepted games."
+      no_games_available: "No games available."
+      no_rejected: "You have no rejected games."
+      no_under_moderation: "You have no games under moderation."
+      rejected: "Rejected games"
+      under_moderation: "Games under moderation"
     show:
       tags: "Tags"
       tags_not_found: "Tags not found"
@@ -86,6 +138,19 @@ en:
       comment_placeholder: "Enter comment... (optional)"
       save: "Save"
       no_author: "Author not found"
+      this_game: "This game"
+      status_pending: "is under moderation"
+      status_rejected: "was rejected by a moderator"
+      criterion_votes_title: "Votes by criteria"
+      criterion_header: "Criterion"
+      votes_header: "Votes"
+      jam_not_found: "Jam not found."
+      your_criteria_score: "Your score by criteria"
+      edit_criteria_scores: "Edit criteria scores"
+      rate_by_criteria: "Rate by criteria"
+      voting_unavailable: "Voting is not available for you (closed or no rights)."
+      participant_scores: "Participant scores"
+      overall_score: "Overall score:"
     form:
       name: "Name"
       desc: "Description"
@@ -96,6 +161,8 @@ en:
       hint1: "Drag file or press to choose file"
       hint2: "(.zip, .rar, .7z, max size 100 MB)"
       recommend: "(recommend 1920х1080px)"
+      cover_preview_alt: "Cover preview"
+      submitting: "Submitting..."
     edit:
       current_file: "Current file: "
       download: "Download archive"
@@ -118,6 +185,7 @@ en:
       inc_empt: "No incoming requests yet"
       accept: "Accept"
       cancel: "Cancel"
+      cancel_inv: "Cancel"
   jams:
     create:
       failure: "Jam with that name already exists."
@@ -134,6 +202,15 @@ en:
       checkbox: "Search with at least one of chosen tags"
       reset_options: "Reset filters"
       no_result: "Nothing was found"
+      no_author: "Author not found"
+      all_jams: "All jams"
+      my_jams: "My jams"
+      accepted: "Accepted jams"
+      no_accepted: "You have no accepted jams."
+      under_moderation: "Jams under moderation"
+      no_under_moderation: "You have no jams under moderation."
+      rejected: "Rejected jams"
+      no_rejected: "You have no rejected jams."
     show:
       description: "Description"
       author: "Author"
@@ -147,6 +224,22 @@ en:
       participate: "Participate"
       change_game: "Change game"
       no_tags: "Tags not found"
+      this_jam: "This jam"
+      status_pending: "is under moderation"
+      status_rejected: "was rejected by a moderator"
+      jam_info: "Jam information"
+      start_date: "Start date:"
+      deadline: "Submission deadline:"
+      end_date: "Voting end:"
+      creator: "Creator:"
+      no_author: "Author not found"
+      hosts: "Hosts:"
+      no_hosts: "No hosts assigned"
+      nominations_winners: "Nomination winners"
+      rating_settings: "Rating settings"
+      jury_settings: "Jury settings"
+      submission_closed: "Submissions are closed"
+      submission_closed_edit: "Submissions are closed. Editing and replacing a game are unavailable."
     form:
       name: "Jam name"
       desc: "Description"
@@ -157,9 +250,12 @@ en:
       logo: "Logo"
       tags: "Tags"
       btn: "Create jam"
-      hint1: "Drag 
+      hint1: "Drag
       image or press to choose file"
       hint2: "(recommend 1920x1080px)"
+      cover_preview_alt: "Cover preview"
+      logo_preview_alt: "Logo preview"
+      submitting: "Submitting..."
     edit:
       name: "Jam name"
       desc: "Description"
@@ -173,17 +269,67 @@ en:
     show_participants:
       title: "All participants"
       no_participants: "There are no participants yet"
+      remove: "Remove"
+      remove_confirm: "Are you sure you want to remove this participant from the jam?"
+      remove_hint: '(Click "Remove" to exclude a participant)'
     show_projects:
       title: "Projects"
       no_projects: "No games have been downloaded yet"
       not_found: "Nothing was found"
       no_author: "Author not found"
+      remove_project: "Remove project"
+      remove_project_confirm: "Are you sure you want to detach this game from the jam?"
+      remove_hint: "(You can remove a project by clicking the button next to the game)"
     modal_content:
       title: "Choose"
       your_games: "Your games"
       your_games_hint: "Choose one of your games:"
       add_new: "Add new game"
       add_existing: "Add existing game"
+    rating_settings:
+      title: "Rating settings"
+      jury_enabled_label: "Jury (yes/no)"
+      audience_enabled_label: "Audience (yes/no)"
+      both_disabled_hint: "You cannot select \"no\" for both"
+      criteria_title: "Rating criteria"
+      criteria_hint: "Criterion name (score is always 0..5)"
+      criterion_placeholder: "For example: Gameplay"
+      kind_voted_on: "Voted on"
+      kind_manually_ranked: "1 vote per game"
+      nominations_title: "Nominations"
+      nominations_hint: "Nomination is assigned by the admin at the end"
+      nomination_placeholder: "For example: Best art"
+    jury_settings:
+      title: "Jury settings"
+      invite_title: "Invite user"
+      search_user_label: "Search user"
+      search_placeholder: "Name or email"
+      search_prompt: "Start typing a name or email…"
+      search_too_short: "Enter at least 2 characters"
+    jury_contributors_table:
+      title: "Members (host/admin/judge)"
+      user: "User"
+      status: "Status"
+      host: "Host"
+      admin: "Admin"
+      judge: "Judge"
+      actions: "Actions"
+      remove: "Remove"
+      pending: "(pending)"
+      save_all: "Save all"
+    jury_search_results:
+      empty: "Nothing found"
+      invite: "Invite"
+    nominations_winners:
+      title: "Winners by nomination"
+      empty: "No nominations"
+      not_selected: "— not selected —"
+    showcase_grid:
+      start: "Start:"
+      deadline: "Submissions until:"
+      creator: "Creator:"
+      no_author: "Author not found"
+      hosts: "Hosts:"
   users:
     destroy:
       success: "The account has been successfully deleted."
@@ -218,6 +364,16 @@ en:
       decline: "Decline invitation"
       no_subscribers: "No subscribers yet"
       no_friends: "No friends yet"
+      user_frozen: "User is frozen!"
+      unfreeze_at: "Unfreeze date:"
+      frozen_indefinitely: "Indefinitely"
+      cancel_application: "Cancel application"
+      accept_application: "Accept application"
+      show_all_games: "Show all games"
+      hide_games: "Hide games"
+      role_author: "Author"
+      role_host: "Host"
+      role_admin: "Admin"
     new:
       title: "Sign up your account"
       email: "Email address"
@@ -241,6 +397,11 @@ en:
         billing: "Billing"
         teams: "Teams"
         integrations: "Integrations"
+      placeholders:
+        field: "Some field"
+        billing_title: "Some field (billing)"
+        teams_title: "Some field (teams)"
+        integrations_title: "Some field (integrations)"
       account:
         title: "Personal information"
         image:
@@ -248,6 +409,7 @@ en:
           or: "or"
           drag: "Drag an image here or click to select a file"
           recommendation: "Recommended size: 1920x1080 pixels"
+          preview_alt: "Image preview"
         nickname: "Nickname"
         real_name: "Full name"
         email:
@@ -288,6 +450,9 @@ en:
           ip: "IP Address: "
           browser: "Browser: "
           created: "Created at: "
+          view_all: "View all sessions"
+          hide_all: "Hide all sessions"
+          none: "No active sessions found."
         delete:
           title: "Delete account"
           hint: "No longer want to use our service? You can delete your account here. This action is not reversible. All information related to this account will be deleted permanently."
@@ -317,11 +482,27 @@ en:
     show_all: "Show all"
     sent: "want to be your friend"
     accept: "accept your request"
+    gray_search:
+      accept_jury_invite: "Accept invitation"
+    report_form:
+      open_btn: "Report"
+      title: "Submit a report"
+      reason_label: "Reason for the report"
+      reason_placeholder: "Describe your report"
+      max_length: "Maximum 300 characters!"
+      submit: "Send"
+      submitting: "Sending..."
+      other_reason: "Other reason"
+      generic_error: "An error occurred while submitting the report"
+      success_title: "Report submitted!"
+      success_body: "Thank you for your report. We will review it shortly."
+      error_title: "Error"
   notifications:
     index:
       title: "Notifications"
       accept: "accepted your friend request"
       sent: "sent a friend request"
+      accept_jury_invite: "Accept invitation"
   email_confirms:
     edit:
       title: "Email confirmation"
@@ -329,3 +510,347 @@ en:
       confirm: "Confirm"
       back: "Back to"
       login: "login page"
+      warning: "Attention: You must confirm your email within an hour of registration, otherwise your account will be deleted"
+    update:
+      success: "Email Confirmed successfully."
+      failure: "Something went wrong."
+      code_blank: "Code cannot be empty"
+      user_not_found: "User not found."
+      invalid_code: "Code is invalid!"
+  controllers:
+    application:
+      insufficient_rights: "Insufficient rights"
+      account_frozen: "Your account is frozen"
+    jams:
+      participate_success: "You have successfully joined the jam!"
+      participate_failure: "An error occurred. Please try again."
+      moderation_pending: "Jam is under moderation"
+      update_resubmitted: "Jam updated and resubmitted for moderation!"
+      participant_removed: "Participant removed from the jam."
+      participant_remove_failed: "Failed to remove participant."
+      project_unlinked: "Project unlinked from the jam."
+      project_unlink_failed: "Failed to remove project."
+      settings_locked: "Settings are locked"
+      ratings_saved: "Rating settings saved"
+      user_not_found: "User not found"
+      invite_sent: "Invitation sent"
+      invite_not_found: "Invitation not found"
+      invite_accepted: "You have accepted the invitation"
+      invite_accept_failed: "Failed to accept the invitation"
+      roles_updated: "Roles updated"
+      contributor_removed: "Removed"
+      winner_saved: "Winner saved"
+      game_not_in_jam: "Game does not participate in this jam"
+      submission_closed: "Submissions are closed"
+      date_deadline_before_start: "Deadline cannot be earlier than the start date"
+      date_end_before_deadline: "End date cannot be earlier than the deadline"
+      date_invalid_start: "Invalid start date"
+      date_invalid_deadline: "Invalid deadline"
+      date_invalid_end: "Invalid end date"
+      invalid_dates: "Please enter valid dates"
+    games:
+      moderation_pending: "Game is under moderation"
+      not_participating: "You are not participating in this jam"
+      not_found: "Game not found"
+      edit_locked: "Submissions are closed. Game editing is unavailable"
+    jam_votes:
+      insufficient_rights_jury: "Insufficient rights to vote as jury"
+      insufficient_rights_audience: "Insufficient rights to vote as audience"
+      scores_saved: "Scores saved"
+      not_in_jam: "This game is not participating in this jam"
+      own_game: "You cannot rate your own game"
+      voting_closed: "Voting is currently closed"
+      voting_disabled: "Voting is disabled"
+      insufficient_rights: "Insufficient rights to vote"
+    jam_criterion_picks:
+      pick_saved: "Choice saved"
+      pick_cleared: "Choice cleared"
+    sessions:
+      account_token_expired: "Your account was deleted due to token expiration. Please register again."
+      email_letter_sent: "A login letter has already been sent to your email"
+      instructions_sent: "Instructions have been sent to your address"
+      all_sessions_logged_out: "All sessions successfully logged out"
+      sessions_logout_failed: "Failed to log out sessions"
+      session_logged_out: "Session successfully logged out"
+      session_logout_failed: "Failed to log out session"
+    password_resets:
+      instructions_sent: "Instructions have been sent to your address"
+      email_not_found: "The specified email was not found"
+      success: "Password successfully updated!"
+      failure: "Something went wrong!"
+      fields_blank: "All fields must be filled in"
+      too_short: "New password is too short (minimum is 5 characters)."
+      no_match: "New passwords do not match."
+      same_as_old: "New password must be different from the old one."
+      invalid_token: "Token is invalid!"
+    users:
+      instructions_sent: "Instructions have been sent to your address"
+      invalid_password: "Invalid password."
+    admin:
+      games:
+        updated: "Game successfully updated"
+        deleted: "Game successfully deleted"
+      jams:
+        updated: "Jam successfully updated"
+        deleted: "Jam successfully deleted"
+      users:
+        created: "User successfully created"
+        updated: "User successfully updated"
+        deleted: "User successfully deleted"
+        invalid_duration: "Invalid duration"
+        freeze_failed: "Failed to freeze user"
+        unfreeze_failed: "Failed to unfreeze user"
+    moderator:
+      games:
+        updated: "Game successfully updated"
+        deleted: "Game successfully deleted"
+      jams:
+        updated: "Jam successfully updated"
+        deleted: "Jam successfully deleted"
+    reports:
+      sent: "Report successfully submitted"
+      notification: "New report on %{type} with id %{id}"
+  mailers:
+    email_confirm:
+      subject: "Confirm email | Jammer"
+      title: "Email confirmation"
+      body: "You need to confirm your email address to register on Jammer. Please copy this code to confirm:"
+    password_reset:
+      subject: "Reset password | Jammer"
+      title: "Password reset"
+      body_intro: "Someone has requested a password reset for your account."
+      body_action: "If it was you, click the button below to set a new password:"
+      button: "Reset my password"
+      body_ignore: "If you did not request a password reset, simply ignore this message."
+  password_resets:
+    new:
+      title: "Password reset"
+      email_label: "Enter your email"
+      submit: "Send"
+      back: "Back"
+    edit:
+      title: "Password reset"
+      password_label: "New password"
+      password_confirmation_label: "Confirm password"
+      back: "Back to"
+      login: "login"
+  jam_votes:
+    new:
+      jam_label: "Jam:"
+      overall_score: "Overall score (by criteria)"
+      one_vote: "1 vote"
+      comment_placeholder: "Comment (optional)"
+  jam_criterion_picks:
+    pick_block:
+      you_picked: "You have picked this game"
+      cancel: "Cancel"
+      currently_picked: "Currently picked:"
+      other_game: "another game"
+      no_pick: "No pick made"
+      pick_instead: "Pick instead"
+      pick_game: "Pick game"
+  admin:
+    shared:
+      back: "Back"
+      save: "Save"
+      search: "Search"
+      reset: "Reset"
+      edit: "Edit"
+      delete: "Delete"
+      confirm: "Are you sure?"
+      tags: "Tags"
+      author_unknown: "Author unknown"
+      status_hint: "0 - Moderation; 1 - Approved; 2 - Rejected"
+      rejection_reason: "Rejection reason"
+      rejection_reasons:
+        indecent_content: "Indecent content"
+        advertising: "Advertising"
+        plagiarism: "Plagiarism"
+    actions:
+      index:
+        title: "Admin actions"
+        admin: "Admin"
+        record_type: "Record type"
+        record_id: "Record ID"
+        action: "Action"
+        changes: "Changes"
+        date: "Date"
+        old_values: "Old values:"
+        new_values: "New values:"
+        no_changes: "No changes"
+    games:
+      index:
+        search_label: "Search games"
+        not_found: 'No games found for query "%{query}".'
+      form:
+        cover: "Cover"
+        game_file: "Game file"
+        current_file: "Current file:"
+        download_archive: "Download archive"
+    jams:
+      index:
+        search_label: "Search jams"
+        not_found: 'No jams found for query "%{query}".'
+      form:
+        start_date: "Start date"
+        deadline: "Submission deadline"
+        end_date: "Jam end date"
+        cover: "Cover"
+        logo: "Logo"
+    users:
+      index:
+        search_label: "Search users"
+        not_found: 'No users found for query "%{query}".'
+        create_user: "Create user"
+      new:
+        title: "Create user"
+        name: "Name"
+        email: "Email"
+        password: "Password"
+        password_confirmation: "Password confirmation"
+        role: "Role"
+        submit: "Create"
+      form:
+        tabs:
+          profile: "Profile"
+          user_experience: "User experience"
+          games: "Games"
+          jams: "Jams"
+          sessions: "Sessions"
+          notifications: "Notifications"
+        avatar: "Avatar"
+        background_image: "Background image"
+        background_preview_alt: "Background preview"
+        upload_new_background: "Upload new background"
+        personal_link: "Personal link"
+        phone_number: "Phone number"
+        birthday: "Birthday"
+        no_info: "No information"
+        freeze:
+          freeze: "Freeze"
+          unfreeze: "Unfreeze"
+          cancel: "Cancel"
+          modal_title: "Freeze account"
+          reason: "Reason"
+          reason_placeholder: "Specify the reason..."
+          reason_required: "Specify a reason"
+          freezing: "Freezing..."
+          error: "Failed to freeze user"
+          unfreeze_error: "Failed to unfreeze user"
+          duration: "Duration"
+          durations:
+            hour_1: "1 hour"
+            hours_6: "6 hours"
+            hours_12: "12 hours"
+            day_1: "1 day"
+            days_3: "3 days"
+            days_7: "7 days"
+            month_1: "1 month"
+            months_6: "6 months"
+            year_1: "1 year"
+            forever: "Forever"
+        frozen:
+          title: "Account frozen"
+          reason: "Reason:"
+          unfreeze_at: "Unfreeze at:"
+        friends:
+          title: "Friends"
+          empty: "No friends yet"
+        requests:
+          title: "Outgoing requests"
+          empty_outgoing: "No outgoing requests yet"
+        subscribers:
+          title: "Subscribers"
+          empty_incoming: "No incoming requests yet"
+        games_section:
+          title: "Games"
+        jams_section:
+          title: "Jams"
+        sessions_section:
+          title: "Sessions"
+          empty: "No active sessions"
+        notifications_section:
+          title: "Notifications"
+          empty: "No notifications"
+          accepted_friendship: "accepted your friend request"
+          sent_friend_request: "sent you a friend request"
+    visits:
+      index:
+        title: "Visit statistics"
+        last_30_days: "Last 30 days"
+        last_90_days: "Last 90 days"
+        active_users: "Active users"
+        registered_users: "Registered users"
+        user_count: "User count"
+        date: "Date"
+  admins:
+    index:
+      title: "Admin panel"
+      go: "Open"
+      users:
+        title: "Users"
+        description: "User management"
+      games:
+        title: "Games"
+        description: "Game editing"
+      jams:
+        title: "Jams"
+        description: "Jam editing"
+      stats:
+        title: "Statistics"
+        description: "Site visit statistics"
+      settings:
+        title: "Settings"
+        description: "Site settings"
+      support:
+        title: "Support"
+        description: "User support"
+      actions:
+        title: "Action log"
+        description: "Admin action history"
+  moderator:
+    shared:
+      back: "Back"
+      save: "Save"
+      search: "Search"
+      reset: "Reset"
+      edit: "Edit"
+      delete: "Delete"
+      confirm: "Are you sure?"
+      tags: "Tags"
+      author_unknown: "Author unknown"
+      status_hint: "0 - Moderation; 1 - Approved; 2 - Rejected"
+      rejection_reason: "Rejection reason"
+      rejection_reasons:
+        indecent_content: "Indecent content"
+        advertising: "Advertising"
+        plagiarism: "Plagiarism"
+    games:
+      index:
+        search_label: "Search games"
+        not_found: 'No games found for query "%{query}".'
+      form:
+        cover: "Cover"
+        game_file: "Game file"
+        current_file: "Current file:"
+        download_archive: "Download archive"
+    jams:
+      index:
+        search_label: "Search jams"
+        not_found: 'No jams found for query "%{query}".'
+      form:
+        start_date: "Start date"
+        deadline: "Submission deadline"
+        end_date: "Jam end date"
+        cover: "Cover"
+        logo: "Logo"
+  moderators:
+    index:
+      title: "Moderator panel"
+      go: "Open"
+      games:
+        title: "Games"
+        description: "Game editing"
+      jams:
+        title: "Jams"
+        description: "Jam editing"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,38 +5,65 @@ en:
     models:
       tag: "Tag"
       game: "Game"
+      jam: "Jam"
+      report: "Report"
+      user: "User"
     attributes:
       game:
         name: "Name"
         description: "Description"
+        cover: "Cover"
+        game_file: "Game file"
+        tags: "Tags"
+        author: "Author"
+        reason: "Reason"
+      jam:
+        name: "Name"
+        description: "Description"
+        cover: "Cover"
+        logo: "Logo"
+        tags: "Tags"
+        author: "Author"
+        start_date: "Start date"
+        deadline: "Deadline"
+        end_date: "End date"
+        reason: "Reason"
+      user:
+        name: "Username"
+        email: "Email"
+        password: "Password"
+        password_confirmation: "Password confirmation"
+      report:
+        reason: "Reason"
+        comment: "Comment"
     errors:
       models:
         game:
           attributes:
             cover:
-              blank: "Cover image is required"
+              blank: "is required"
             game_file:
-              blank: "Game file is required"
-              wrong_format: "File must be in .zip, .rar or .7z format"
-              too_large: "Archive size must not exceed 100 MB"
+              blank: "is required"
+              wrong_format: "must be .zip, .rar or .7z"
+              too_large: "size must not exceed 100 MB"
             tags:
-              too_long: "No more than %{count} tags can be selected"
+              too_long: "may not contain more than %{count} items"
         jam:
           attributes:
             cover:
-              blank: "Cover image is required"
+              blank: "is required"
             logo:
-              blank: "Logo image is required"
+              blank: "is required"
             description:
-              blank: "Description is required"
+              blank: "is required"
             tags:
-              too_long: "No more than %{count} tags can be selected"
+              too_long: "may not contain more than %{count} items"
         report:
           attributes:
             reportable_id:
-              taken: "You have already filed a report on this entity"
+              taken: "you have already filed a report on this entity"
         jam_rating_setting:
-          both_disabled: "You cannot disable both jury and audience at the same time"
+          both_disabled: "you cannot disable both jury and audience at the same time"
   buttons:
     save: "Save"
     change_avatar: "Change avatar"
@@ -503,6 +530,17 @@ en:
       accept: "accepted your friend request"
       sent: "sent a friend request"
       accept_jury_invite: "Accept invitation"
+    actions:
+      accepted_friendship: "accepted your friend request"
+      accepted_friend_request: "accepted your friend request"
+      sent_friend_request: "sent you a friend request"
+      awaiting_game_moderation: "— game awaits moderation"
+      awaiting_jam_moderation: "— jam awaits moderation"
+      game_status_changed: "— game status changed after moderation"
+      jam_status_changed: "— jam status changed after moderation"
+      sent_jam_jury_invite: "invited you to the jury"
+      accepted_jam_jury_invite: "accepted the jury invitation"
+      new_report: "filed a new report on %{type} (id %{id})"
   email_confirms:
     edit:
       title: "Email confirmation"
@@ -609,7 +647,6 @@ en:
         deleted: "Jam successfully deleted"
     reports:
       sent: "Report successfully submitted"
-      notification: "New report on %{type} with id %{id}"
   mailers:
     email_confirm:
       subject: "Confirm email | Jammer"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -5,38 +5,65 @@ ru:
     models:
       tag: "Тег"
       game: "Игра"
+      jam: "Джем"
+      report: "Жалоба"
+      user: "Пользователь"
     attributes:
       game:
         name: "Название"
         description: "Описание"
+        cover: "Обложка"
+        game_file: "Файл игры"
+        tags: "Теги"
+        author: "Автор"
+        reason: "Причина"
+      jam:
+        name: "Название"
+        description: "Описание"
+        cover: "Обложка"
+        logo: "Логотип"
+        tags: "Теги"
+        author: "Автор"
+        start_date: "Дата начала"
+        deadline: "Дедлайн сдачи работ"
+        end_date: "Дата окончания"
+        reason: "Причина"
+      user:
+        name: "Имя пользователя"
+        email: "Электронная почта"
+        password: "Пароль"
+        password_confirmation: "Подтверждение пароля"
+      report:
+        reason: "Причина"
+        comment: "Комментарий"
     errors:
       models:
         game:
           attributes:
             cover:
-              blank: "Обложка обязательна для загрузки"
+              blank: "обязательна для загрузки"
             game_file:
-              blank: "Файл игры обязателен для загрузки"
-              wrong_format: "Файл должен быть в формате .zip, .rar или .7z"
-              too_large: "Размер архива не должен превышать 100 MB"
+              blank: "обязателен для загрузки"
+              wrong_format: "должен быть в формате .zip, .rar или .7z"
+              too_large: "размер не должен превышать 100 MB"
             tags:
-              too_long: "Можно выбрать не более %{count} тегов"
+              too_long: "может содержать не более %{count} элементов"
         jam:
           attributes:
             cover:
-              blank: "Обложка обязательна для загрузки"
+              blank: "обязательна для загрузки"
             logo:
-              blank: "Логотип обязателен для загрузки"
+              blank: "обязателен для загрузки"
             description:
-              blank: "Описание обязательно для заполнения"
+              blank: "обязательно для заполнения"
             tags:
-              too_long: "Можно выбрать не более %{count} тегов"
+              too_long: "может содержать не более %{count} элементов"
         report:
           attributes:
             reportable_id:
-              taken: "Вы уже отправили жалобу на эту сущность"
+              taken: "вы уже отправили жалобу на эту сущность"
         jam_rating_setting:
-          both_disabled: "Нельзя выключить и жюри, и аудиторию одновременно"
+          both_disabled: "нельзя выключить и жюри, и аудиторию одновременно"
   buttons:
     save: "Сохранить"
     change_avatar: "Сменить аватарку"
@@ -503,6 +530,17 @@ ru:
       accept: "принял заявку в друзья"
       sent: "отправил запрос в друзья"
       accept_jury_invite: "Принять приглашение"
+    actions:
+      accepted_friendship: "принял вашу заявку в друзья"
+      accepted_friend_request: "принял вашу заявку в друзья"
+      sent_friend_request: "отправил вам заявку в друзья"
+      awaiting_game_moderation: "— игра ожидает модерацию"
+      awaiting_jam_moderation: "— джем ожидает модерацию"
+      game_status_changed: "— статус игры изменён после модерации"
+      jam_status_changed: "— статус джема изменён после модерации"
+      sent_jam_jury_invite: "пригласил вас в жюри"
+      accepted_jam_jury_invite: "принял приглашение в жюри"
+      new_report: "оставил новую жалобу на %{type} (id %{id})"
   email_confirms:
     edit:
       title: "Подтверждение почты"
@@ -609,7 +647,6 @@ ru:
         deleted: "Джем успешно удалён"
     reports:
       sent: "Жалоба успешно отправлена"
-      notification: "Новая жалоба на %{type} с id %{id}"
   mailers:
     email_confirm:
       subject: "Подтверждение email | Jammer"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -9,6 +9,34 @@ ru:
       game:
         name: "Название"
         description: "Описание"
+    errors:
+      models:
+        game:
+          attributes:
+            cover:
+              blank: "Обложка обязательна для загрузки"
+            game_file:
+              blank: "Файл игры обязателен для загрузки"
+              wrong_format: "Файл должен быть в формате .zip, .rar или .7z"
+              too_large: "Размер архива не должен превышать 100 MB"
+            tags:
+              too_long: "Можно выбрать не более %{count} тегов"
+        jam:
+          attributes:
+            cover:
+              blank: "Обложка обязательна для загрузки"
+            logo:
+              blank: "Логотип обязателен для загрузки"
+            description:
+              blank: "Описание обязательно для заполнения"
+            tags:
+              too_long: "Можно выбрать не более %{count} тегов"
+        report:
+          attributes:
+            reportable_id:
+              taken: "Вы уже отправили жалобу на эту сущность"
+        jam_rating_setting:
+          both_disabled: "Нельзя выключить и жюри, и аудиторию одновременно"
   buttons:
     save: "Сохранить"
     change_avatar: "Сменить аватарку"
@@ -17,6 +45,8 @@ ru:
     profile: "Профиль"
     sign_out: "Выйти"
     add_friend: "Добавить в друзья"
+    cancel: "Отмена"
+    close: "Закрыть"
   search: "Поиск..."
   home:
     title: "Прототип сервиса Jammer"
@@ -40,6 +70,18 @@ ru:
       requests: "Запросы"
       settings: "Настройки"
       plug: "Заглушка"
+    application:
+      logo_alt: "Логотип"
+      admin_panel: "Панель администратора"
+      moderator_panel: "Панель модератора"
+      team_initial: "П"
+    is_frozen:
+      title: "Вы заморожены!"
+      reason: "Причина:"
+      frozen_at: "Заморозка была установлена:"
+      frozen_until: "Заморожено до:"
+      indefinitely: "Бессрочно"
+      contact: "Если у вас есть вопросы, свяжитесь с нами по адресу:"
   dashboard:
     index:
       title: "Панель управления"
@@ -49,6 +91,8 @@ ru:
       jams_games_rating: "Средняя оценка ваших игр в Джемах: "
       jams_reviews: "Ваши отзывы в джемах: "
       no_comment: "Комментарий не оставлен"
+      my_jams: "Мои джемы"
+      no_jams: "Вы пока не участвуете и не администрируете ни в одном джеме."
   games:
     create:
       success: "Игра успешно создана!"
@@ -67,6 +111,14 @@ ru:
       checkbox: "Искать хотя бы с одним из выбранных тегов"
       not_found: "По текущему запросу ничего не найдено"
       no_author: "Автор не найден"
+      all_games: "Все игры"
+      my_games: "Мои игры"
+      no_accepted: "У вас нет принятых игр."
+      no_games_available: "Нет доступных игр."
+      no_rejected: "У вас нет отклонённых игр."
+      no_under_moderation: "У вас нет игр на модерации."
+      rejected: "Отклонённые игры"
+      under_moderation: "Игры на модерации"
     show:
       tags: "Теги"
       tags_not_found: "Теги не найдены"
@@ -86,6 +138,19 @@ ru:
       comment_placeholder: "Введите комментарий... (необязательно)"
       save: "Сохранить"
       no_author: "Автор не найден"
+      this_game: "Данная игра"
+      status_pending: "находится на модерации"
+      status_rejected: "отклонена модератором"
+      criterion_votes_title: "Голоса по критериям"
+      criterion_header: "Критерий"
+      votes_header: "Голоса"
+      jam_not_found: "Джем не найден."
+      your_criteria_score: "Оценка по критериям"
+      edit_criteria_scores: "Изменить оценки по критериям"
+      rate_by_criteria: "Оценить по критериям"
+      voting_unavailable: "Оценивание для вас недоступно (закрыто или нет прав)."
+      participant_scores: "Оценки участников"
+      overall_score: "Общая оценка:"
     form:
       name: "Название"
       desc: "Описание"
@@ -96,6 +161,8 @@ ru:
       hint1: "Перетащите сюда файл или нажмите, чтобы выбрать файл"
       hint2: "(.zip, .rar, .7z, размер до 100 MБ)"
       recommend: "(рекомендуем разрешение 1920х1080)"
+      cover_preview_alt: "Предварительный просмотр обложки"
+      submitting: "Создаем..."
     edit:
       current_file: "Текущий файл: "
       download: "Скачать архив"
@@ -135,6 +202,15 @@ ru:
       checkbox: "Искать с хотя бы одним из выбранных тегов"
       reset_options: "Сбросить фильтры"
       no_result: "По текущему запросу ничего не найдено"
+      no_author: "Автор не найден"
+      all_jams: "Все джемы"
+      my_jams: "Мои джемы"
+      accepted: "Принятые джемы"
+      no_accepted: "У вас нет принятых джемов."
+      under_moderation: "Джемы на модерации"
+      no_under_moderation: "У вас нет джемов на модерации."
+      rejected: "Отклонённые джемы"
+      no_rejected: "У вас нет отклонённых джемов."
     show:
       description: "Описание"
       author: "Автор"
@@ -148,6 +224,22 @@ ru:
       participate: "Участвовать"
       change_game: "Заменить игру"
       no_tags: "Теги не найдены"
+      this_jam: "Данный джем"
+      status_pending: "находится на модерации"
+      status_rejected: "отклонен модератором"
+      jam_info: "Информация о джеме"
+      start_date: "Дата начала:"
+      deadline: "Окончание приёма работ:"
+      end_date: "Окончание оценивания:"
+      creator: "Создатель:"
+      no_author: "Автор не найден"
+      hosts: "Хосты:"
+      no_hosts: "Хосты не назначены"
+      nominations_winners: "Победители по номинациям"
+      rating_settings: "Настройки оценок"
+      jury_settings: "Настройки жюри"
+      submission_closed: "Приём работ завершён"
+      submission_closed_edit: "Приём работ завершён. Редактирование и замена игры недоступны."
     form:
       name: "Название джема"
       desc: "Описание"
@@ -158,9 +250,12 @@ ru:
       logo: "Логотип"
       tags: "Теги"
       btn: "Создать джем"
-      hint1: "Перетащите 
+      hint1: "Перетащите
       сюда изображение или нажмите, чтобы выбрать файл"
       hint2: "(рекомендуем 1920x1080px)"
+      cover_preview_alt: "Предварительный просмотр обложки"
+      logo_preview_alt: "Предварительный просмотр логотипа"
+      submitting: "Создаем..."
     edit:
       name: "Название джема"
       desc: "Описание"
@@ -174,17 +269,67 @@ ru:
     show_participants:
       title: "Все участники"
       no_participants: "Пока в данном джеме никто не участвует"
+      remove: "Удалить"
+      remove_confirm: "Вы уверены, что хотите удалить этого участника из джема?"
+      remove_hint: '(Нажмите "Удалить", чтобы исключить участника)'
     show_projects:
       title: "Список проектов"
       no_projects: "Ни одна игра еще не была загружена"
       not_found: "По текущему запросу ничего не найдено"
       no_author: "Автор не найден"
+      remove_project: "Удалить проект"
+      remove_project_confirm: "Вы уверены, что хотите отвязать эту игру от джема?"
+      remove_hint: "(Вы можете удалить проект, нажав на кнопку рядом с игрой)"
     modal_content:
       title: "Выберите"
       your_games: "Ваши игры"
       your_games_hint: "Выберите одну из ваших игр:"
       add_new: "Добавить новую игру"
       add_existing: "Добавить существующую игру"
+    rating_settings:
+      title: "Настройки оценок"
+      jury_enabled_label: "Жюри (да/нет)"
+      audience_enabled_label: "Аудитория (да/нет)"
+      both_disabled_hint: "Нельзя выбрать два раза \"нет\""
+      criteria_title: "Критерии оценивания"
+      criteria_hint: "Название критерия (оценка всегда 0..5)"
+      criterion_placeholder: "Например: Геймплей"
+      kind_voted_on: "Балльная оценка"
+      kind_manually_ranked: "1 голос за игру"
+      nominations_title: "Номинации"
+      nominations_hint: "Номинацию присваивает админ в конце"
+      nomination_placeholder: "Например: Лучший арт"
+    jury_settings:
+      title: "Настройки жюри"
+      invite_title: "Пригласить пользователя"
+      search_user_label: "Поиск пользователя"
+      search_placeholder: "Имя или email"
+      search_prompt: "Начните вводить имя или email…"
+      search_too_short: "Введите минимум 2 символа"
+    jury_contributors_table:
+      title: "Участники (host/admin/judge)"
+      user: "Пользователь"
+      status: "Статус"
+      host: "Хост"
+      admin: "Админ"
+      judge: "Жюри"
+      actions: "Действия"
+      remove: "Удалить"
+      pending: "(ожидает)"
+      save_all: "Сохранить всё"
+    jury_search_results:
+      empty: "Ничего не найдено"
+      invite: "Пригласить"
+    nominations_winners:
+      title: "Победители по номинациям"
+      empty: "Номинаций нет"
+      not_selected: "— не выбрано —"
+    showcase_grid:
+      start: "Начало:"
+      deadline: "Приём работ до:"
+      creator: "Создатель:"
+      no_author: "Автор не найден"
+      hosts: "Хосты:"
   users:
     destroy:
       success: "Аккаунт успешно удален."
@@ -219,6 +364,16 @@ ru:
       decline: "Отклонить заявку"
       no_subscribers: "Подписчиков пока нет"
       no_friends: "Друзей пока нет"
+      user_frozen: "Пользователь заморожен!"
+      unfreeze_at: "Дата разморозки:"
+      frozen_indefinitely: "Бессрочно"
+      cancel_application: "Отменить заявку"
+      accept_application: "Принять заявку"
+      show_all_games: "Показать все игры"
+      hide_games: "Скрыть игры"
+      role_author: "Автор"
+      role_host: "Хост"
+      role_admin: "Админ"
     new:
       title: "Зарегистрируйте свой аккаунт"
       email: "Адрес электронной почты"
@@ -242,6 +397,11 @@ ru:
         billing: "Счета"
         teams: "Команды"
         integrations: "Интеграции"
+      placeholders:
+        field: "Какое-то поле"
+        billing_title: "Какое-то поле (billing)"
+        teams_title: "Какое-то поле (teams)"
+        integrations_title: "Какое-то поле (integrations)"
       account:
         title: "Персональная информация"
         image:
@@ -249,6 +409,7 @@ ru:
           or: "или"
           drag: "Перетащите сюда изображение или нажмите, чтобы выбрать файл"
           recommendation: "Рекомендуемый размер: 1920x1080 пикселей"
+          preview_alt: "Предварительный просмотр изображения"
         nickname: "Отображаемое имя"
         real_name: "Настоящее имя"
         email:
@@ -289,6 +450,9 @@ ru:
           ip: "IP Адрес: "
           browser: "Браузер: "
           created: "Дата создания: "
+          view_all: "Показать все сессии"
+          hide_all: "Скрыть все сессии"
+          none: "Активных сессий не найдено."
         delete:
           title: "Удалить аккаунт"
           hint: "Больше не хотите пользоваться нашим сервисом? Вы можете удалить свою учетную запись здесь. Это действие необратимо. Вся информация, связанная с этой учетной записью, будет удалена навсегда."
@@ -318,11 +482,27 @@ ru:
     show_all: "Показать все"
     sent: "отправил запрос в друзья"
     accept: "принял вашу заявку"
+    gray_search:
+      accept_jury_invite: "Принять приглашение"
+    report_form:
+      open_btn: "Пожаловаться"
+      title: "Оставить жалобу"
+      reason_label: "Причина жалобы"
+      reason_placeholder: "Опишите вашу жалобу"
+      max_length: "Максимум 300 символов!"
+      submit: "Отправить"
+      submitting: "Отправка..."
+      other_reason: "Другая причина"
+      generic_error: "Произошла ошибка при отправке жалобы"
+      success_title: "Жалоба отправлена!"
+      success_body: "Спасибо за вашу жалобу. Мы рассмотрим её в ближайшее время."
+      error_title: "Ошибка"
   notifications:
     index:
       title: "Уведомления"
       accept: "принял заявку в друзья"
       sent: "отправил запрос в друзья"
+      accept_jury_invite: "Принять приглашение"
   email_confirms:
     edit:
       title: "Подтверждение почты"
@@ -330,3 +510,347 @@ ru:
       confirm: "Подтвердить"
       back: "Вернуться ко "
       login: "входу"
+      warning: "Внимание: Почту необходимо подтвердить в течение часа после регистрации, иначе ваш аккаунт будет удален"
+    update:
+      success: "Почта успешно подтверждена."
+      failure: "Что-то пошло не так."
+      code_blank: "Код не может быть пуст"
+      user_not_found: "Пользователь не найден."
+      invalid_code: "Код недействителен!"
+  controllers:
+    application:
+      insufficient_rights: "Недостаточно прав"
+      account_frozen: "Ваш аккаунт заморожен"
+    jams:
+      participate_success: "Вы успешно присоединились к джему!"
+      participate_failure: "Произошла ошибка. Попробуйте еще раз."
+      moderation_pending: "Джем находится на модерации"
+      update_resubmitted: "Джем обновлен и отправлен на повторную модерацию!"
+      participant_removed: "Участник удалён из джема."
+      participant_remove_failed: "Не удалось удалить участника."
+      project_unlinked: "Проект отвязан от джема."
+      project_unlink_failed: "Не удалось удалить проект."
+      settings_locked: "Настройки заблокированы"
+      ratings_saved: "Настройки оценок сохранены"
+      user_not_found: "Пользователь не найден"
+      invite_sent: "Инвайт отправлен"
+      invite_not_found: "Инвайт не найден"
+      invite_accepted: "Вы приняли приглашение"
+      invite_accept_failed: "Не удалось принять приглашение"
+      roles_updated: "Роли обновлены"
+      contributor_removed: "Удалено"
+      winner_saved: "Победитель сохранён"
+      game_not_in_jam: "Игра не участвует в этом джеме"
+      submission_closed: "Приём работ завершён"
+      date_deadline_before_start: "Дата сдачи работ не может быть раньше даты начала"
+      date_end_before_deadline: "Дата окончания джема не может быть раньше даты сдачи работ"
+      date_invalid_start: "Некорректная дата начала джема"
+      date_invalid_deadline: "Некорректная дата сдачи работ"
+      date_invalid_end: "Некорректная дата окончания джема"
+      invalid_dates: "Пожалуйста, введите корректные даты"
+    games:
+      moderation_pending: "Игра находится на модерации"
+      not_participating: "Вы не участвуете в этом джеме"
+      not_found: "Игра не найдена"
+      edit_locked: "Приём работ завершён. Редактирование игры недоступно"
+    jam_votes:
+      insufficient_rights_jury: "Недостаточно прав для голосования жюри"
+      insufficient_rights_audience: "Недостаточно прав для голосования аудитории"
+      scores_saved: "Оценки сохранены"
+      not_in_jam: "Эта игра не участвует в данном джеме"
+      own_game: "Нельзя оценивать собственную игру"
+      voting_closed: "Голосование сейчас закрыто"
+      voting_disabled: "Голосование отключено"
+      insufficient_rights: "Недостаточно прав для голосования"
+    jam_criterion_picks:
+      pick_saved: "Выбор сохранён"
+      pick_cleared: "Выбор сброшен"
+    sessions:
+      account_token_expired: "Ваш аккаунт был удален из-за истечения срока действия токена. Пожалуйста, зарегистрируйтесь снова."
+      email_letter_sent: "Письмо с кодом для входа уже было отправлено на вашу почту"
+      instructions_sent: "Инструкции были отправлены на ваш адрес"
+      all_sessions_logged_out: "Все сессии успешно удалены"
+      sessions_logout_failed: "Не удалось удалить сессии"
+      session_logged_out: "Сессия успешно удалена"
+      session_logout_failed: "Не удалось удалить сессию"
+    password_resets:
+      instructions_sent: "Инструкции были отправлены на ваш адрес"
+      email_not_found: "Не найдена указанная почта"
+      success: "Пароль успешно обновлен!"
+      failure: "Что-то пошло не так!"
+      fields_blank: "Все поля должны быть заполнены."
+      too_short: "Новый пароль слишком короткий (минимум 5 символов)."
+      no_match: "Новые пароли не совпадают."
+      same_as_old: "Новый пароль должен отличаться от старого."
+      invalid_token: "Токен недействителен!"
+    users:
+      instructions_sent: "Инструкции были отправлены на ваш адрес"
+      invalid_password: "Неверный пароль."
+    admin:
+      games:
+        updated: "Игра успешно обновлена"
+        deleted: "Игра успешно удалена"
+      jams:
+        updated: "Джем успешно обновлен"
+        deleted: "Джем успешно удалён"
+      users:
+        created: "Пользователь успешно создан"
+        updated: "Пользователь успешно обновлен"
+        deleted: "Пользователь успешно удален"
+        invalid_duration: "Некорректный срок"
+        freeze_failed: "Не удалось заморозить пользователя"
+        unfreeze_failed: "Не удалось разморозить пользователя"
+    moderator:
+      games:
+        updated: "Игра успешно обновлена"
+        deleted: "Игра успешно удалена"
+      jams:
+        updated: "Джем успешно обновлен"
+        deleted: "Джем успешно удалён"
+    reports:
+      sent: "Жалоба успешно отправлена"
+      notification: "Новая жалоба на %{type} с id %{id}"
+  mailers:
+    email_confirm:
+      subject: "Подтверждение email | Jammer"
+      title: "Подтверждение электронной почты"
+      body: "Вам необходимо подтвердить адрес электронной почты для регистрации на Jammer. Пожалуйста, скопируйте этот код для подтверждения:"
+    password_reset:
+      subject: "Сброс пароля | Jammer"
+      title: "Сброс пароля"
+      body_intro: "Кто-то запросил сброс пароля для вашей учетной записи."
+      body_action: "Если это были вы, нажмите на кнопку ниже, чтобы установить новый пароль:"
+      button: "Сбросить мой пароль"
+      body_ignore: "Если вы не запрашивали сброс пароля, просто проигнорируйте это сообщение."
+  password_resets:
+    new:
+      title: "Сброс пароля"
+      email_label: "Введите ваш email"
+      submit: "Отправить"
+      back: "Назад"
+    edit:
+      title: "Сброс пароля"
+      password_label: "Новый пароль"
+      password_confirmation_label: "Подтверждение пароля"
+      back: "Вернуться ко"
+      login: "входу"
+  jam_votes:
+    new:
+      jam_label: "Джем:"
+      overall_score: "Общая оценка (по критериям)"
+      one_vote: "1 голос"
+      comment_placeholder: "Комментарий (необязательно)"
+  jam_criterion_picks:
+    pick_block:
+      you_picked: "Вы выбрали эту игру"
+      cancel: "Отменить"
+      currently_picked: "Сейчас выбрано:"
+      other_game: "другая игра"
+      no_pick: "Выбор не сделан"
+      pick_instead: "Выбрать вместо"
+      pick_game: "Выбрать игру"
+  admin:
+    shared:
+      back: "Назад"
+      save: "Сохранить"
+      search: "Поиск"
+      reset: "Сбросить"
+      edit: "Редактировать"
+      delete: "Удалить"
+      confirm: "Вы уверены?"
+      tags: "Теги"
+      author_unknown: "Автор неизвестен"
+      status_hint: "0 - Модерация; 1 - Одобрено; 2 - Отклонено"
+      rejection_reason: "Причина отклонения"
+      rejection_reasons:
+        indecent_content: "Непристойный контент"
+        advertising: "Реклама"
+        plagiarism: "Плагиат"
+    actions:
+      index:
+        title: "Действия администраторов"
+        admin: "Администратор"
+        record_type: "Тип записи"
+        record_id: "ID записи"
+        action: "Действие"
+        changes: "Изменения"
+        date: "Дата"
+        old_values: "Старые значения:"
+        new_values: "Новые значения:"
+        no_changes: "Изменений нет"
+    games:
+      index:
+        search_label: "Поиск игр"
+        not_found: 'Игры не найдены по запросу "%{query}".'
+      form:
+        cover: "Обложка"
+        game_file: "Файл игры"
+        current_file: "Текущий файл:"
+        download_archive: "Скачать архив"
+    jams:
+      index:
+        search_label: "Поиск джемов"
+        not_found: 'Джемы не найдены по запросу "%{query}".'
+      form:
+        start_date: "Дата начала"
+        deadline: "Дедлайн сдачи работ"
+        end_date: "Дата окончания джема"
+        cover: "Обложка"
+        logo: "Логотип"
+    users:
+      index:
+        search_label: "Поиск пользователей"
+        not_found: 'Пользователи не найдены по запросу "%{query}".'
+        create_user: "Создать пользователя"
+      new:
+        title: "Создание пользователя"
+        name: "Имя"
+        email: "Email"
+        password: "Пароль"
+        password_confirmation: "Подтверждение пароля"
+        role: "Роль"
+        submit: "Создать"
+      form:
+        tabs:
+          profile: "Профиль"
+          user_experience: "Пользовательский опыт"
+          games: "Игры"
+          jams: "Джемы"
+          sessions: "Сессии"
+          notifications: "Уведомления"
+        avatar: "Аватар"
+        background_image: "Фоновое изображение"
+        background_preview_alt: "Предпросмотр фона"
+        upload_new_background: "Загрузить новый фон"
+        personal_link: "Персональная ссылка"
+        phone_number: "Номер телефона"
+        birthday: "Дата рождения"
+        no_info: "Информации нет"
+        freeze:
+          freeze: "Заморозить"
+          unfreeze: "Разморозить"
+          cancel: "Отмена"
+          modal_title: "Заморозка аккаунта"
+          reason: "Причина"
+          reason_placeholder: "Укажите причину..."
+          reason_required: "Укажите причину"
+          freezing: "Заморозка..."
+          error: "Не удалось заморозить пользователя"
+          unfreeze_error: "Не удалось разморозить пользователя"
+          duration: "Срок"
+          durations:
+            hour_1: "1 час"
+            hours_6: "6 часов"
+            hours_12: "12 часов"
+            day_1: "1 день"
+            days_3: "3 дня"
+            days_7: "7 дней"
+            month_1: "1 месяц"
+            months_6: "6 месяцев"
+            year_1: "1 год"
+            forever: "Навсегда"
+        frozen:
+          title: "Аккаунт заморожен"
+          reason: "Причина:"
+          unfreeze_at: "Разморозка:"
+        friends:
+          title: "Друзья"
+          empty: "Друзей пока нет"
+        requests:
+          title: "Исходящие заявки"
+          empty_outgoing: "Исходящих заявок пока нет"
+        subscribers:
+          title: "Подписчики"
+          empty_incoming: "Входящих заявок пока нет"
+        games_section:
+          title: "Игры"
+        jams_section:
+          title: "Джемы"
+        sessions_section:
+          title: "Сессии"
+          empty: "Активных сессий нет"
+        notifications_section:
+          title: "Уведомления"
+          empty: "Уведомлений нет"
+          accepted_friendship: "принял вашу заявку в друзья"
+          sent_friend_request: "отправил вам заявку в друзья"
+    visits:
+      index:
+        title: "Статистика посещений"
+        last_30_days: "Последние 30 дней"
+        last_90_days: "Последние 90 дней"
+        active_users: "Активные пользователи"
+        registered_users: "Зарегистрированные пользователи"
+        user_count: "Количество пользователей"
+        date: "Дата"
+  admins:
+    index:
+      title: "Панель администратора"
+      go: "Перейти"
+      users:
+        title: "Пользователи"
+        description: "Управление пользователями"
+      games:
+        title: "Игры"
+        description: "Редактирование игр"
+      jams:
+        title: "Джемы"
+        description: "Редактирование джемов"
+      stats:
+        title: "Статистика"
+        description: "Статистика посещений сайта"
+      settings:
+        title: "Настройки"
+        description: "Настройки сайта"
+      support:
+        title: "Поддержка"
+        description: "Поддержка пользователей"
+      actions:
+        title: "Журнал действий"
+        description: "История действий администраторов"
+  moderator:
+    shared:
+      back: "Назад"
+      save: "Сохранить"
+      search: "Поиск"
+      reset: "Сбросить"
+      edit: "Редактировать"
+      delete: "Удалить"
+      confirm: "Вы уверены?"
+      tags: "Теги"
+      author_unknown: "Автор неизвестен"
+      status_hint: "0 - Модерация; 1 - Одобрено; 2 - Отклонено"
+      rejection_reason: "Причина отклонения"
+      rejection_reasons:
+        indecent_content: "Непристойный контент"
+        advertising: "Реклама"
+        plagiarism: "Плагиат"
+    games:
+      index:
+        search_label: "Поиск игр"
+        not_found: 'Игры не найдены по запросу "%{query}".'
+      form:
+        cover: "Обложка"
+        game_file: "Файл игры"
+        current_file: "Текущий файл:"
+        download_archive: "Скачать архив"
+    jams:
+      index:
+        search_label: "Поиск джемов"
+        not_found: 'Джемы не найдены по запросу "%{query}".'
+      form:
+        start_date: "Дата начала"
+        deadline: "Дедлайн сдачи работ"
+        end_date: "Дата окончания джема"
+        cover: "Обложка"
+        logo: "Логотип"
+  moderators:
+    index:
+      title: "Панель модератора"
+      go: "Перейти"
+      games:
+        title: "Игры"
+        description: "Редактирование игр"
+      jams:
+        title: "Джемы"
+        description: "Редактирование джемов"

--- a/config/version.yml
+++ b/config/version.yml
@@ -1,3 +1,3 @@
 major:     0
-minor:     3
-patch:     5
+minor:     4
+patch:     0


### PR DESCRIPTION
- Translate models, controllers, mailers, Stimulus controllers and views to use I18n.t
- Add ~300 locale keys across en/ru (controllers, admin, moderator, mailers, JS strings, validations)
- Models use Rails error key conventions; mailers pass current locale via deliver_later params
- Stimulus controllers (freeze, unfreeze, autosubmit, jams, report, visits) read user-facing strings from data-* values
- deploy.yml pulls Docker registry username from KAMAL_REGISTRY_USERNAME via .kamal/secrets/.env (@Fiitovec99 fyi)